### PR TITLE
feat: JWT 예외 처리 전략 및 필터 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ build/
 
 # Package Files #
 *.jar
+hs_err_pid*
+replay_pid*
 *.war
 *.nar
 *.ear

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+# kilo
+.kilo
+.skills
+
 # temp
 .temp
+.playwright-mcp
 
 # env
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-# .env
+# temp
+.temp
+
+# env
 .env
 
 # storage
@@ -25,12 +28,6 @@ build/
 # Log file
 *.log
 
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
 # Package Files #
 *.jar
 *.war
@@ -39,7 +36,3 @@ build/
 *.zip
 *.tar.gz
 *.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,8 @@ def jacocoExcludePatterns = [
         "**/constant/**",
         "**/logging/**",
         "**/Q*.class",
+        "**/OAuth2Provider*.class",
+        "**/*UserDetails.class",
         "**/*MapperImpl.class",
         "**/*Properties.class",
         "**/*Decorator.class",

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ def jacocoExcludePatterns = [
         "**/mapper/**",
         "**/constant/**",
         "**/logging/**",
+        "**/auth/infra/security/**",
         "**/Q*.class",
         "**/*MapperImpl.class",
         "**/*Properties.class",
@@ -125,7 +126,10 @@ def jacocoExcludePatterns = [
         "**/package-info.class",
         "**/JwtToken.class",
         "**/JwtRegistry.class",
+        "**/port/out/**",
         "**/common/**",
+        "**/model/ParsedToken.class",
+        "**/AuthCookieProvider.class",
 ]
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,6 @@ def jacocoExcludePatterns = [
         "**/mapper/**",
         "**/constant/**",
         "**/logging/**",
-        "**/auth/infra/security/**",
         "**/Q*.class",
         "**/*MapperImpl.class",
         "**/*Properties.class",

--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.00
+                minimum = 0.80
             }
         }
     }

--- a/src/main/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistScheduler.java
+++ b/src/main/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistScheduler.java
@@ -3,6 +3,7 @@ package io.github.metdaisy.amaazon.auth.application.scheduler;
 import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistTokenRepository;
 import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistUserRepository;
 import java.time.Instant;
+import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ public class BlacklistScheduler {
 
   private final BlacklistTokenRepository blacklistTokenRepository;
   private final BlacklistUserRepository blacklistUserRepository;
+  private final Clock clock;
 
   @Value("${amaazon.jwt.refresh-token-expiration}")
   private long refreshTokenExpiration;
@@ -25,7 +27,7 @@ public class BlacklistScheduler {
   @Scheduled(cron = "0 0 * * * ?")
   @Transactional
   public void cleanupBlacklistToken() {
-    Instant now = Instant.now();
+    Instant now = Instant.now(clock);
     log.info("Starting blacklist token cleanup scheduler at {}", now);
     try {
       blacklistTokenRepository.deleteByExpiredAtLessThanEqual(now);
@@ -38,7 +40,7 @@ public class BlacklistScheduler {
   @Scheduled(cron = "0 0 0 * * ?")
   @Transactional
   public void cleanupBlacklistUser() {
-    Instant now = Instant.now();
+    Instant now = Instant.now(clock);
     log.info("Starting blacklist user cleanup scheduler at {}", now);
     try {
       Instant compromisedThreshold = now.minus(refreshTokenExpiration, ChronoUnit.SECONDS);

--- a/src/main/java/io/github/metdaisy/amaazon/global/config/GlobalConfig.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/config/GlobalConfig.java
@@ -6,11 +6,19 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
+import org.springframework.context.annotation.Bean;
+import java.time.Clock;
+
 @EnableJpaAuditing
 @EnableAsync
 @EnableCaching
 @EnableWebSecurity
 @Configuration
 public class GlobalConfig {
+
+  @Bean
+  public Clock clock() {
+    return Clock.systemUTC();
+  }
 
 }

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/GlobalExceptionHandler.java
@@ -1,17 +1,8 @@
 package io.github.metdaisy.amaazon.global.exception;
 
-import io.github.metdaisy.amaazon.common.exception.AmaazonException;
-import io.github.metdaisy.amaazon.global.exception.util.ErrorTypeResolver;
-import io.github.metdaisy.amaazon.global.exception.util.ViolationExceptionUtils;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.ConstraintViolationException;
 import java.io.IOException;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.task.TaskRejectedException;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -20,67 +11,42 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import io.github.metdaisy.amaazon.common.exception.AmaazonException;
+import io.github.metdaisy.amaazon.global.exception.strategy.ExceptionStrategyFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+  private final HttpServletRequest request;
+  private final ExceptionStrategyFactory strategyFactory;
+
   @ExceptionHandler(AmaazonException.class)
   public ResponseEntity<ApiErrorResponse> handleBusinessException(AmaazonException e) {
-    log.warn(e.toString());
-    return ResponseEntity
-            .status(ErrorTypeResolver.resolve(e.getErrorType()))
-            .body(ApiErrorResponse.from(e));
+    return strategyFactory.getStrategy(AmaazonException.class).buildResponse(e);
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(
-          MethodArgumentNotValidException e) {
-    String detailedErrorLog = e.getBindingResult().getFieldErrors().stream()
-            .map(error -> String.format("필드 [%s] - 입력값: [%s], 원인: [%s]",
-                    error.getField(),
-                    error.getRejectedValue(),
-                    error.getDefaultMessage()))
-            .collect(Collectors.joining(" | "));
-    log.warn("유효성 검사 실패 (MethodArgumentNotValidException) -> {}", detailedErrorLog);
-    return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiErrorResponse.from(e));
+      MethodArgumentNotValidException e) {
+    return strategyFactory.getStrategy(MethodArgumentNotValidException.class).buildResponse(e);
   }
 
   @ExceptionHandler(ConstraintViolationException.class)
   public ResponseEntity<ApiErrorResponse> handleConstraintViolationException(
-          ConstraintViolationException e) {
-    String detailedErrorLog = e.getConstraintViolations().stream()
-            .map(v -> String.format("경로 [%s] - 입력값: [%s], 원인: [%s]",
-                    v.getPropertyPath(),
-                    v.getInvalidValue(),
-                    v.getMessage()))
-            .collect(Collectors.joining(" | "));
-
-    boolean isFromController = ViolationExceptionUtils.isFromController(e);
-    if (isFromController) {
-      log.warn("제약조건 위반 (ConstraintViolationException) -> {}", detailedErrorLog);
-    } else {
-      log.error("제약조건 위반 (ConstraintViolationException) -> {}", detailedErrorLog, e);
-    }
-
-    HttpStatus status =
-            isFromController ? HttpStatus.BAD_REQUEST : HttpStatus.INTERNAL_SERVER_ERROR;
-    return ResponseEntity
-            .status(status)
-            .body(ApiErrorResponse.from(e));
+      ConstraintViolationException e) {
+    return strategyFactory.getStrategy(ConstraintViolationException.class).buildResponse(e);
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<ApiErrorResponse> handleHttpMessageNotReadableException(
-          HttpMessageNotReadableException e
-  ) {
-    log.warn("요청 본문을 읽을 수 없음 (HttpMessageNotReadableException) -> {}", e.getMessage());
-    return ResponseEntity
-            .badRequest()
-            .body(ApiErrorResponse.from(e));
+      HttpMessageNotReadableException e) {
+    return strategyFactory.getStrategy(HttpMessageNotReadableException.class).buildResponse(e);
   }
 
   // 클라이언트가 SSE 연결을 끊을 때(브라우저 탭 닫기, 새로고침 등) 응답 스트림에 쓰다가 발생하는
@@ -88,68 +54,44 @@ public class GlobalExceptionHandler {
   // ERROR로 로그를 남기지 않고 조용히 무시한다.
   @ExceptionHandler(IOException.class)
   public void handleIOException(IOException e) {
-    log.debug("클라이언트 연결 종료로 응답 전송 실패: {}", e.getMessage());
+    strategyFactory.getStrategy(IOException.class).buildResponse(e);
   }
 
   // 존재하지 않는 경로로의 요청(봇/스캐너의 무작위 경로 탐색)에서 발생
   // 버그가 아니므로 ERROR로 로그를 남기지 않고 404만 반환
   @ExceptionHandler(NoResourceFoundException.class)
   public ResponseEntity<ApiErrorResponse> handleNoResourceFoundException(
-          NoResourceFoundException e, HttpServletRequest request) {
-    log.warn("존재하지 않는 리소스 요청: {} | User-Agent: {}",
-            e.getMessage(), request.getHeader("User-Agent"));
-    return ResponseEntity
-            .status(HttpStatus.NOT_FOUND)
-            .body(new ApiErrorResponse("NOT_FOUND", "요청하신 리소스를 찾을 수 없습니다.", null));
+      NoResourceFoundException e) {
+    return strategyFactory.buildNoResourceFoundResponse(e, request);
   }
 
   // 배치 작업 스레드 풀의 큐까지 가득 찬 상태에서 새 수집 요청이 들어오면 AbortPolicy가
   // TaskRejectedException을 던진다. 일시적인 과부하이므로 503으로 매핑해 재시도를 유도한다.
   @ExceptionHandler(TaskRejectedException.class)
   public ResponseEntity<ApiErrorResponse> handleTaskRejectedException(TaskRejectedException e) {
-    log.warn("배치 작업 큐 포화로 요청 거부: {}", e.getMessage());
-    return ResponseEntity
-            .status(HttpStatus.SERVICE_UNAVAILABLE)
-            .body(new ApiErrorResponse("SERVICE_UNAVAILABLE",
-                    "현재 수집 작업이 많아 요청을 처리할 수 없습니다. 잠시 후 다시 시도해주세요.", null));
+    return strategyFactory.getStrategy(TaskRejectedException.class).buildResponse(e);
   }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiErrorResponse> handleException(Exception e) {
-    log.error("Unexpected exception", e);
-    return ResponseEntity
-            .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(new ApiErrorResponse("INTERNAL_SERVER_ERROR",
-                    "서버 내부 에러가 발생했습니다.", null));
+    return strategyFactory.getStrategy(Exception.class).buildResponse(e);
   }
 
   @ExceptionHandler(MissingServletRequestParameterException.class)
   public ResponseEntity<ApiErrorResponse> handleMissingServletRequestParameterException(
-          MissingServletRequestParameterException e
-  ) {
-    log.warn(e.toString());
-    return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiErrorResponse.from(e));
+      MissingServletRequestParameterException e) {
+    return strategyFactory.getStrategy(MissingServletRequestParameterException.class).buildResponse(e);
   }
 
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   public ResponseEntity<ApiErrorResponse> handleMethodArgumentTypeMismatchException(
-          MethodArgumentTypeMismatchException e
-  ) {
-    log.warn(e.toString());
-    return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiErrorResponse.from(e));
+      MethodArgumentTypeMismatchException e) {
+    return strategyFactory.getStrategy(MethodArgumentTypeMismatchException.class).buildResponse(e);
   }
 
   @ExceptionHandler(DataIntegrityViolationException.class)
   public ResponseEntity<ApiErrorResponse> handleDataIntegrityViolationException(
-          DataIntegrityViolationException e
-  ) {
-    log.warn("데이터 무결성 제약조건 위반: {}", e.getMessage());
-    return ResponseEntity
-            .status(HttpStatus.CONFLICT)
-            .body(ApiErrorResponse.from(e));
+      DataIntegrityViolationException e) {
+    return strategyFactory.getStrategy(DataIntegrityViolationException.class).buildResponse(e);
   }
 }

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/AbstractExceptionResponseStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/AbstractExceptionResponseStrategy.java
@@ -1,0 +1,45 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 예외 응답 전략의 추상 기반 클래스
+ */
+@Slf4j
+public abstract class AbstractExceptionResponseStrategy<T extends Exception> implements ExceptionResponseStrategy<T> {
+
+  /**
+   * 예외 메시지를 반환하는지 여부
+   */
+  protected abstract boolean logExceptionMessage();
+
+  /**
+   * API 응답 오류 객체를 생성합니다.
+   */
+  protected abstract ApiErrorResponse createErrorResponse(T exception);
+
+  protected void logException(T exception) {
+    if (logExceptionMessage()) {
+      log.warn(exception.toString());
+    }
+  }
+
+  protected HttpStatus getHttpStatus(T exception) {
+    return HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+
+  /**
+   * 전체 응답 엔티티를 생성합니다.
+   */
+  @Override
+  public ResponseEntity<ApiErrorResponse> buildResponse(T exception) {
+    logException(exception);
+    return ResponseEntity
+        .status(getHttpStatus(exception))
+        .body(createErrorResponse(exception));
+  }
+
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/AmaazonExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/AmaazonExceptionStrategy.java
@@ -1,0 +1,27 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import org.springframework.http.HttpStatus;
+import io.github.metdaisy.amaazon.common.exception.AmaazonException;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import io.github.metdaisy.amaazon.global.exception.util.ErrorTypeResolver;
+
+/**
+ * AmaazonException 처리 전략
+ */
+public class AmaazonExceptionStrategy extends AbstractExceptionResponseStrategy<AmaazonException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return true;
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(AmaazonException exception) {
+    return ApiErrorResponse.from(exception);
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(AmaazonException exception) {
+    return ErrorTypeResolver.resolve(exception.getErrorType());
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/ConstraintViolationExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/ConstraintViolationExceptionStrategy.java
@@ -1,0 +1,49 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import io.github.metdaisy.amaazon.global.exception.util.ViolationExceptionUtils;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * ConstraintViolationException 처리 전략
+ */
+@Slf4j
+public class ConstraintViolationExceptionStrategy
+    extends AbstractExceptionResponseStrategy<ConstraintViolationException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return true;
+  }
+
+  @Override
+  protected void logException(ConstraintViolationException exception) {
+    String detailedErrorLog = exception.getConstraintViolations().stream()
+        .map(v -> String.format("경로 [%s] - 입력값: [%s], 원인: [%s]",
+            v.getPropertyPath(),
+            v.getInvalidValue(),
+            v.getMessage()))
+        .collect(Collectors.joining(" | "));
+
+    boolean isFromController = ViolationExceptionUtils.isFromController(exception);
+    if (isFromController) {
+      log.warn("제약조건 위반 (ConstraintViolationException) -> {}", detailedErrorLog);
+    } else {
+      log.error("제약조건 위반 (ConstraintViolationException) -> {}", detailedErrorLog, exception);
+    }
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(ConstraintViolationException exception) {
+    return ApiErrorResponse.from(exception);
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(ConstraintViolationException exception) {
+    boolean isFromController = ViolationExceptionUtils.isFromController(exception);
+    return isFromController ? HttpStatus.BAD_REQUEST : HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/DataIntegrityViolationExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/DataIntegrityViolationExceptionStrategy.java
@@ -1,0 +1,34 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * DataIntegrityViolationException 처리 전략
+ */
+@Slf4j
+public class DataIntegrityViolationExceptionStrategy
+    extends AbstractExceptionResponseStrategy<DataIntegrityViolationException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return true;
+  }
+
+  @Override
+  protected void logException(DataIntegrityViolationException exception) {
+    log.warn("데이터 무결성 제약조건 위반: {}", exception.getMessage());
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(DataIntegrityViolationException exception) {
+    return ApiErrorResponse.from(exception);
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(DataIntegrityViolationException exception) {
+    return HttpStatus.CONFLICT;
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/ExceptionResponseStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/ExceptionResponseStrategy.java
@@ -1,0 +1,16 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import org.springframework.http.ResponseEntity;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+
+/**
+ * 예외 유형별 응답 생성 전략 인터페이스
+ */
+public interface ExceptionResponseStrategy<T extends Exception> {
+
+  /**
+   * 전체 응답 엔티티를 생성합니다.
+   */
+  ResponseEntity<ApiErrorResponse> buildResponse(T exception);
+
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/ExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/ExceptionStrategy.java
@@ -1,0 +1,28 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 일반 Exception 처리 전략
+ */
+@Slf4j
+public class ExceptionStrategy extends AbstractExceptionResponseStrategy<Exception> {
+
+  @Override
+  public boolean logExceptionMessage() {
+    return false;
+  }
+
+  @Override
+  public void logException(Exception exception) {
+    log.error("Unexpected exception", exception);
+  }
+
+  @Override
+  public ApiErrorResponse createErrorResponse(Exception exception) {
+    return new ApiErrorResponse("INTERNAL_SERVER_ERROR",
+        "서버 내부 에러가 발생했습니다.", null);
+  }
+
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/ExceptionStrategyFactory.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/ExceptionStrategyFactory.java
@@ -1,0 +1,75 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.GenericTypeResolver;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 예외 유형별 전략을 관리하는 팩토리
+ */
+@Slf4j
+@Component
+public class ExceptionStrategyFactory {
+
+  private final Map<Class<?>, ExceptionResponseStrategy<?>> strategyMap = new HashMap<>();
+
+  public ExceptionStrategyFactory() {
+    initializeStrategies();
+  }
+
+  private void initializeStrategies() {
+    ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false);
+    provider.addIncludeFilter(new AssignableTypeFilter(ExceptionResponseStrategy.class));
+
+    String basePackage = this.getClass().getPackage().getName();
+    provider.findCandidateComponents(basePackage).forEach(this::registerStrategy);
+  }
+
+  private void registerStrategy(BeanDefinition component) {
+    try {
+      Class<?> clazz = Class.forName(component.getBeanClassName());
+      
+      if (Modifier.isAbstract(clazz.getModifiers()) || clazz.isInterface()) {
+        return;
+      }
+
+      ExceptionResponseStrategy<?> strategy = (ExceptionResponseStrategy<?>) clazz.getDeclaredConstructor().newInstance();
+      Class<?>[] typeArgs = GenericTypeResolver.resolveTypeArguments(clazz, ExceptionResponseStrategy.class);
+      
+      if (typeArgs != null && typeArgs.length > 0) {
+        Class<?> exceptionClass = typeArgs[0];
+        strategyMap.put(exceptionClass, strategy);
+        log.debug("Registered Strategy: {} for Exception: {}", clazz.getSimpleName(), exceptionClass.getSimpleName());
+      }
+    } catch (Exception e) {
+      log.error("Failed to initialize ExceptionResponseStrategy: {}", component.getBeanClassName(), e);
+      throw new IllegalStateException("전략 클래스 초기화 실패", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends Exception> ExceptionResponseStrategy<T> getStrategy(Class<T> exceptionClass) {
+    return (ExceptionResponseStrategy<T>) strategyMap.getOrDefault(exceptionClass, strategyMap.get(Exception.class));
+  }
+
+  /**
+   * HttpServletRequest를 사용하여 NoResourceFoundException 응답을 생성합니다.
+   */
+  public ResponseEntity<ApiErrorResponse> buildNoResourceFoundResponse(
+      NoResourceFoundException exception,
+      HttpServletRequest request) {
+    return ((NoResourceFoundExceptionStrategy) strategyMap.get(NoResourceFoundException.class))
+        .buildResponse(exception, request);
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/HttpMessageNotReadableExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/HttpMessageNotReadableExceptionStrategy.java
@@ -1,0 +1,34 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * HttpMessageNotReadableException 처리 전략
+ */
+@Slf4j
+public class HttpMessageNotReadableExceptionStrategy
+    extends AbstractExceptionResponseStrategy<HttpMessageNotReadableException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return true;
+  }
+
+  @Override
+  protected void logException(HttpMessageNotReadableException exception) {
+    log.warn("요청 본문을 읽을 수 없음 (HttpMessageNotReadableException) -> {}", exception.getMessage());
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(HttpMessageNotReadableException exception) {
+    return ApiErrorResponse.from(exception);
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(HttpMessageNotReadableException exception) {
+    return HttpStatus.BAD_REQUEST;
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/IOExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/IOExceptionStrategy.java
@@ -1,0 +1,35 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * IOException 처리 전략 (SSE 연결 종료 등)
+ */
+@Slf4j
+public class IOExceptionStrategy extends AbstractExceptionResponseStrategy<IOException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return false;
+  }
+
+  @Override
+  protected void logException(IOException exception) {
+    log.debug("클라이언트 연결 종료로 응답 전송 실패: {}", exception.getMessage());
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(
+      IOException exception) {
+    // IOException은 응답을 반환하지 않음
+    return null;
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(IOException exception) {
+    return HttpStatus.OK;
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/MethodArgumentNotValidExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/MethodArgumentNotValidExceptionStrategy.java
@@ -1,0 +1,41 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MethodArgumentNotValidException 처리 전략
+ */
+@Slf4j
+public class MethodArgumentNotValidExceptionStrategy
+    extends AbstractExceptionResponseStrategy<MethodArgumentNotValidException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return true;
+  }
+
+  @Override
+  protected void logException(MethodArgumentNotValidException exception) {
+    String detailedErrorLog = exception.getBindingResult().getFieldErrors().stream()
+        .map(error -> String.format("필드 [%s] - 입력값: [%s], 원인: [%s]",
+            error.getField(),
+            error.getRejectedValue(),
+            error.getDefaultMessage()))
+        .collect(Collectors.joining(" | "));
+    log.warn("유효성 검사 실패 (MethodArgumentNotValidException) -> {}", detailedErrorLog);
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(MethodArgumentNotValidException exception) {
+    return ApiErrorResponse.from(exception);
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(MethodArgumentNotValidException exception) {
+    return HttpStatus.BAD_REQUEST;
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/MethodArgumentTypeMismatchExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/MethodArgumentTypeMismatchExceptionStrategy.java
@@ -1,0 +1,29 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MethodArgumentTypeMismatchException 처리 전략
+ */
+@Slf4j
+public class MethodArgumentTypeMismatchExceptionStrategy
+    extends AbstractExceptionResponseStrategy<MethodArgumentTypeMismatchException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return true;
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(MethodArgumentTypeMismatchException exception) {
+    return ApiErrorResponse.from(exception);
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(MethodArgumentTypeMismatchException exception) {
+    return HttpStatus.BAD_REQUEST;
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/MissingServletRequestParameterExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/MissingServletRequestParameterExceptionStrategy.java
@@ -1,0 +1,29 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MissingServletRequestParameterException 처리 전략
+ */
+@Slf4j
+public class MissingServletRequestParameterExceptionStrategy
+    extends AbstractExceptionResponseStrategy<MissingServletRequestParameterException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return true;
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(MissingServletRequestParameterException exception) {
+    return ApiErrorResponse.from(exception);
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(MissingServletRequestParameterException exception) {
+    return HttpStatus.BAD_REQUEST;
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/NoResourceFoundExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/NoResourceFoundExceptionStrategy.java
@@ -20,7 +20,12 @@ public class NoResourceFoundExceptionStrategy extends AbstractExceptionResponseS
 
   @Override
   protected void logException(NoResourceFoundException exception) {
-    log.warn("존재하지 않는 리소스 요청: {}", exception.getMessage());
+    String message = sanitize(exception.getMessage());
+    log.warn("존재하지 않는 리소스 요청: {}", message);
+  }
+
+  private String sanitize(String input) {
+    return input == null ? "" : input.replaceAll("[\\r\\n]", "_");
   }
 
   @Override
@@ -38,9 +43,9 @@ public class NoResourceFoundExceptionStrategy extends AbstractExceptionResponseS
    */
   protected ResponseEntity<ApiErrorResponse> buildResponse(NoResourceFoundException exception,
       HttpServletRequest request) {
-    String userAgent = request.getHeader("User-Agent");
-    log.warn("존재하지 않는 리소스 요청: {} | User-Agent: {}",
-        exception.getMessage(), userAgent);
+    String userAgent = sanitize(request.getHeader("User-Agent"));
+    String message = sanitize(exception.getMessage());
+    log.warn("존재하지 않는 리소스 요청: {} | User-Agent: {}", message, userAgent);
     return ResponseEntity
         .status(getHttpStatus(exception))
         .body(createErrorResponse(exception));

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/NoResourceFoundExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/NoResourceFoundExceptionStrategy.java
@@ -1,0 +1,48 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * NoResourceFoundException 처리 전략
+ */
+@Slf4j
+public class NoResourceFoundExceptionStrategy extends AbstractExceptionResponseStrategy<NoResourceFoundException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return true;
+  }
+
+  @Override
+  protected void logException(NoResourceFoundException exception) {
+    log.warn("존재하지 않는 리소스 요청: {}", exception.getMessage());
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(NoResourceFoundException exception) {
+    return new ApiErrorResponse("NOT_FOUND", "요청하신 리소스를 찾을 수 없습니다.", null);
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(NoResourceFoundException exception) {
+    return HttpStatus.NOT_FOUND;
+  }
+
+  /**
+   * HttpServletRequest를 사용하여 응답을 생성합니다. User-Agent 헤더를 로그에 포함합니다.
+   */
+  protected ResponseEntity<ApiErrorResponse> buildResponse(NoResourceFoundException exception,
+      HttpServletRequest request) {
+    String userAgent = request.getHeader("User-Agent");
+    log.warn("존재하지 않는 리소스 요청: {} | User-Agent: {}",
+        exception.getMessage(), userAgent);
+    return ResponseEntity
+        .status(getHttpStatus(exception))
+        .body(createErrorResponse(exception));
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/TaskRejectedExceptionStrategy.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/exception/strategy/TaskRejectedExceptionStrategy.java
@@ -1,0 +1,34 @@
+package io.github.metdaisy.amaazon.global.exception.strategy;
+
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.http.HttpStatus;
+import io.github.metdaisy.amaazon.global.exception.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * TaskRejectedException 처리 전략
+ */
+@Slf4j
+public class TaskRejectedExceptionStrategy extends AbstractExceptionResponseStrategy<TaskRejectedException> {
+
+  @Override
+  protected boolean logExceptionMessage() {
+    return true;
+  }
+
+  @Override
+  protected void logException(TaskRejectedException exception) {
+    log.warn("배치 작업 큐 포화로 요청 거부: {}", exception.getMessage());
+  }
+
+  @Override
+  protected ApiErrorResponse createErrorResponse(TaskRejectedException exception) {
+    return new ApiErrorResponse("SERVICE_UNAVAILABLE",
+        "현재 수집 작업이 많아 요청을 처리할 수 없습니다. 잠시 후 다시 시도해주세요.", null);
+  }
+
+  @Override
+  protected HttpStatus getHttpStatus(TaskRejectedException exception) {
+    return HttpStatus.SERVICE_UNAVAILABLE;
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/AuthenticationBuilder.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/AuthenticationBuilder.java
@@ -9,15 +9,15 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Component;
 import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
 import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
 import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
+import lombok.experimental.UtilityClass;
 
 /**
  * ParsedToken을 Spring Security의 Authentication 객체로 변환하는 빌더입니다. JWT 클레임과 Spring Security 인프라를 분리합니다.
  */
-@Component
+@UtilityClass
 public class AuthenticationBuilder {
 
   /**

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/AuthenticationBuilder.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/AuthenticationBuilder.java
@@ -1,0 +1,45 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.flywaydb.core.internal.util.StringUtils;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
+
+/**
+ * ParsedToken을 Spring Security의 Authentication 객체로 변환하는 빌더입니다. JWT 클레임과 Spring Security 인프라를 분리합니다.
+ */
+@Component
+public class AuthenticationBuilder {
+
+  /**
+   * ParsedToken을 Authentication 객체로 변환합니다.
+   */
+  public Authentication buildAuthentication(ParsedToken token, String tokenString) {
+    String authClaim = token.role();
+    if (!StringUtils.hasText(authClaim)) {
+      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "payload에서 role을 찾을 수 없습니다.");
+    }
+
+    Collection<? extends GrantedAuthority> authorities = parseAuthorities(authClaim);
+    UserDetails principal = new User(token.subject(), "", authorities);
+    return new UsernamePasswordAuthenticationToken(principal, tokenString, authorities);
+  }
+
+  private Collection<? extends GrantedAuthority> parseAuthorities(String authClaim) {
+    return Arrays.stream(authClaim.split(","))
+        .map(String::trim)
+        .map(String::toUpperCase)
+        .map(auth -> auth.startsWith("ROLE_") ? auth : "ROLE_" + auth)
+        .map(SimpleGrantedAuthority::new)
+        .toList();
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/AuthenticationBuilder.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/AuthenticationBuilder.java
@@ -1,18 +1,18 @@
 package io.github.metdaisy.amaazon.global.security.jwt.builder;
 
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
 import java.util.Arrays;
 import java.util.Collection;
-import org.flywaydb.core.internal.util.StringUtils;
+import lombok.experimental.UtilityClass;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
-import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
-import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
-import lombok.experimental.UtilityClass;
+import org.springframework.util.StringUtils;
 
 /**
  * ParsedToken을 Spring Security의 Authentication 객체로 변환하는 빌더입니다. JWT 클레임과 Spring Security 인프라를 분리합니다.

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/SignedTokenFactory.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/SignedTokenFactory.java
@@ -1,0 +1,50 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import org.springframework.stereotype.Component;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * JWTClaimsSet을 서명된 SignedJWT로 변환하는 팩토리입니다. 서명 및 직렬화 로직을 캡슐화합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SignedTokenFactory {
+
+  private final JWSHeader header;
+  private final JWSSigner signer;
+
+  /**
+   * 클레임셋을 서명하여 JWT 문자열로 직렬화합니다.
+   */
+  public String sign(JWTClaimsSet claimsSet) {
+    try {
+      SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+      signedJWT.sign(signer);
+      return signedJWT.serialize();
+    } catch (Exception e) {
+      log.error("JWT 서명 실패", e);
+      throw new JwtException(JwtErrorCode.SIGN_FAILED);
+    }
+  }
+
+  /**
+   * 서명된 JWT의 유효성을 검증합니다.
+   */
+  public boolean verify(SignedJWT signedJWT, JWSVerifier verifier) {
+    try {
+      return signedJWT.verify(verifier);
+    } catch (Exception e) {
+      log.error("JWT 검증 실패", e);
+      return false;
+    }
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenBuilderFactory.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenBuilderFactory.java
@@ -1,0 +1,71 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import java.util.Date;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
+import io.github.metdaisy.amaazon.global.security.jwt.config.JwtProperties;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * JWT 클레임셋(JWTClaimsSet)을 생성하는 팩토리입니다. Access Token, Refresh Token, Guest Token의 클레임셋 생성 로직을
+ * 캡슐화합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class TokenBuilderFactory {
+
+  private final JwtProperties jwtProperties;
+
+  /**
+   * Access Token용 클레임셋을 생성합니다.
+   */
+  public JWTClaimsSet buildAccessTokenClaims(String subject, String authorities) {
+    long now = System.currentTimeMillis();
+    long expirationMillis = jwtProperties.accessTokenExpiration() * 1000;
+
+    JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
+        .jwtID(UUID.randomUUID().toString())
+        .subject(subject)
+        .issueTime(new Date(now))
+        .expirationTime(new Date(now + expirationMillis));
+
+    if (StringUtils.hasText(authorities)) {
+      builder.claim("role", authorities);
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Refresh Token용 클레임셋을 생성합니다.
+   */
+  public JWTClaimsSet buildRefreshTokenClaims(String subject) {
+    long now = System.currentTimeMillis();
+    long expirationMillis = jwtProperties.refreshTokenExpiration() * 1000;
+
+    return new JWTClaimsSet.Builder()
+        .jwtID(UUID.randomUUID().toString())
+        .subject(subject)
+        .issueTime(new Date(now))
+        .expirationTime(new Date(now + expirationMillis))
+        .build();
+  }
+
+  /**
+   * Guest Token용 클레임셋을 생성합니다.
+   */
+  public JWTClaimsSet buildGuestTokenClaims(String provider, String providerId) {
+    long now = System.currentTimeMillis();
+    long expirationMillis = jwtProperties.guestTokenExpiration();
+
+    return new JWTClaimsSet.Builder()
+        .jwtID(UUID.randomUUID().toString())
+        .claim("provider", provider)
+        .claim("providerId", providerId)
+        .issueTime(new Date(now))
+        .expirationTime(new Date(now + expirationMillis))
+        .build();
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParser.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParser.java
@@ -24,7 +24,7 @@ public class TokenParser {
       SignedJWT signedJWT = SignedJWT.parse(token);
       return ParsedToken.from(signedJWT.getJWTClaimsSet());
     } catch (Exception e) {
-      log.error("JWT 토큰 파싱 실패: {}", token, e);
+      log.error("JWT 토큰 파싱 실패", e);
       throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, Map.of("token", token));
     }
   }

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParser.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParser.java
@@ -1,0 +1,62 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import com.nimbusds.jwt.SignedJWT;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * JWT 토큰을 파싱하여 ParsedToken으로 변환하는 파서입니다. SignedJWT 파싱 오버헤드를 줄이기 위해 한 번 파싱한 결과를 ParsedToken으로 캐싱합니다.
+ */
+@Slf4j
+@Component
+public class TokenParser {
+
+  /**
+   * JWT 토큰을 파싱하여 ParsedToken으로 변환합니다.
+   */
+  public ParsedToken parse(String token) {
+    try {
+      SignedJWT signedJWT = SignedJWT.parse(token);
+      return ParsedToken.from(signedJWT.getJWTClaimsSet());
+    } catch (Exception e) {
+      log.error("JWT 토큰 파싱 실패: {}", token, e);
+      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, Map.of("token", token));
+    }
+  }
+
+  /**
+   * 토큰에서 JTI(JWT ID)를 추출합니다.
+   */
+  public String parseJti(ParsedToken token) {
+    if (token.jti() == null) {
+      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "JTI를 찾을 수 없습니다.");
+    }
+    return token.jti();
+  }
+
+  /**
+   * 토큰에서 IssuedAt을 추출합니다.
+   */
+  public Instant parseIssueTime(ParsedToken token) {
+    if (token.issueTime() == null) {
+      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "IssuedAt을 찾을 수 없습니다.");
+    }
+    return Instant.ofEpochSecond(token.issueTime().getTime());
+  }
+
+  /**
+   * 토큰에서 지정된 키의 클레임 값을 추출합니다.
+   */
+  public String parseClaim(ParsedToken token, String key) {
+    Object claim = token.otherClaims().get(key);
+    if (claim == null) {
+      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, key + " 클레임을 찾을 수 없습니다.");
+    }
+    return claim.toString();
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParser.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParser.java
@@ -2,18 +2,18 @@ package io.github.metdaisy.amaazon.global.security.jwt.builder;
 
 import java.time.Instant;
 import java.util.Map;
-import org.springframework.stereotype.Component;
 import com.nimbusds.jwt.SignedJWT;
 import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
 import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
 import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * JWT 토큰을 파싱하여 ParsedToken으로 변환하는 파서입니다. SignedJWT 파싱 오버헤드를 줄이기 위해 한 번 파싱한 결과를 ParsedToken으로 캐싱합니다.
  */
 @Slf4j
-@Component
+@UtilityClass
 public class TokenParser {
 
   /**

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParser.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParser.java
@@ -46,13 +46,16 @@ public class TokenParser {
     if (token.issueTime() == null) {
       throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "IssuedAt을 찾을 수 없습니다.");
     }
-    return Instant.ofEpochSecond(token.issueTime().getTime());
+    return token.issueTime().toInstant();
   }
 
   /**
    * 토큰에서 지정된 키의 클레임 값을 추출합니다.
    */
   public String parseClaim(ParsedToken token, String key) {
+    if (token.otherClaims() == null) {
+      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, key + " 클레임을 찾을 수 없습니다.");
+    }
     Object claim = token.otherClaims().get(key);
     if (claim == null) {
       throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, key + " 클레임을 찾을 수 없습니다.");

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenValidator.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenValidator.java
@@ -54,7 +54,7 @@ public class TokenValidator {
     try {
       return SignedJWT.parse(token);
     } catch (Exception e) {
-      log.error("JWT 토큰 파싱 실패: {}", token, e);
+      log.error("JWT 토큰 파싱 실패", e);
       throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, Map.of("token", token));
     }
   }

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenValidator.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenValidator.java
@@ -1,0 +1,86 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import java.util.Date;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jwt.SignedJWT;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * JWT 토큰의 유효성을 검증하는 검증기입니다. 서명 검증, 만료 시간 검증, 클레임 검증을 담당합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenValidator {
+
+  private final SignedTokenFactory signedTokenFactory;
+
+  /**
+   * 토큰의 서명과 만료 시간을 모두 검증합니다.
+   */
+  public void validate(String token, JWSVerifier verifier) {
+    SignedJWT signedJWT = parseSignedJWT(token);
+    verifySignature(signedJWT, verifier);
+    verifyExpiration(signedJWT);
+  }
+
+  /**
+   * 토큰의 서명만 검증합니다.
+   */
+  public void validateSignature(String token, JWSVerifier verifier) {
+    SignedJWT signedJWT = parseSignedJWT(token);
+    verifySignature(signedJWT, verifier);
+  }
+
+  /**
+   * 토큰의 만료 시간만 검증합니다.
+   */
+  public void validateExpiration(ParsedToken token) {
+    if (token.expirationTime() == null) {
+      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "토큰 유효기간을 찾을 수 없습니다.");
+    }
+    if (token.expirationTime().before(new Date())) {
+      throw new JwtException(JwtErrorCode.TOKEN_EXPIRED);
+    }
+  }
+
+  private SignedJWT parseSignedJWT(String token) {
+    try {
+      return SignedJWT.parse(token);
+    } catch (Exception e) {
+      log.error("JWT 토큰 파싱 실패: {}", token, e);
+      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, Map.of("token", token));
+    }
+  }
+
+  private void verifySignature(SignedJWT signedJWT, JWSVerifier verifier) {
+    boolean verified = signedTokenFactory.verify(signedJWT, verifier);
+    if (!verified) {
+      log.error("JWT 서명 검증 실패");
+      throw new JwtException(JwtErrorCode.VERIFICATION_FAILED);
+    }
+  }
+
+  private void verifyExpiration(SignedJWT signedJWT) {
+    try {
+      java.util.Date expirationTime = signedJWT.getJWTClaimsSet().getExpirationTime();
+      if (expirationTime == null) {
+        throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "claim 파싱을 할 수 없습니다.");
+      }
+      if (expirationTime.before(new java.util.Date())) {
+        throw new JwtException(JwtErrorCode.TOKEN_EXPIRED);
+      }
+    } catch (JwtException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("JWT 만료 시간 검증 실패", e);
+      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "만료 시간 파싱 실패");
+    }
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/config/JwtConfig.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/config/JwtConfig.java
@@ -1,10 +1,35 @@
 package io.github.metdaisy.amaazon.global.security.jwt.config;
 
+import java.nio.charset.StandardCharsets;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.MACVerifier;
+import lombok.RequiredArgsConstructor;
 
+/**
+ * JWT 관련 인프라 구조체(Signer, Verifier, Header)를 Spring Bean으로 관리하는 설정 클래스입니다. JwtTokenProvider 및 내부
+ * 모듈들이 이 Bean들을 주입받아 사용합니다.
+ */
 @Configuration
 @EnableConfigurationProperties(JwtProperties.class)
+@RequiredArgsConstructor
 public class JwtConfig {
 
+  private final JwtProperties jwtProperties;
+
+  @Bean
+  public JWSHeader jwsHeader() {
+    return new JWSHeader(JWSAlgorithm.HS256);
+  }
+
+  @Bean
+  public JWSVerifier jwsVerifier() throws JOSEException {
+    byte[] secretBytes = jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8);
+    return new MACVerifier(secretBytes);
+  }
 }

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/config/JwtConfig.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/config/JwtConfig.java
@@ -1,5 +1,8 @@
 package io.github.metdaisy.amaazon.global.security.jwt.config;
 
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.KeyLengthException;
+import com.nimbusds.jose.crypto.MACSigner;
 import java.nio.charset.StandardCharsets;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -25,6 +28,12 @@ public class JwtConfig {
   @Bean
   public JWSHeader jwsHeader() {
     return new JWSHeader(JWSAlgorithm.HS256);
+  }
+
+  @Bean
+  public JWSSigner jwsSigner() throws KeyLengthException {
+    byte[] secretBytes = jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8);
+    return new MACSigner(secretBytes);
   }
 
   @Bean

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/model/ParsedToken.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/model/ParsedToken.java
@@ -1,0 +1,31 @@
+package io.github.metdaisy.amaazon.global.security.jwt.model;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Map;
+import com.nimbusds.jwt.JWTClaimsSet;
+
+/**
+ * 파싱된 JWT 클레임 정보를 담는 불변 Record 클래스입니다. 토큰 파싱 오버헤드를 줄이기 위해 SignedJWT를 한 번만 파싱하여 이 객체로 변환합니다.
+ */
+public record ParsedToken(
+    String jti,
+    String subject,
+    Date issueTime,
+    Date expirationTime,
+    String role,
+    Map<String, Object> otherClaims) {
+
+  /**
+   * JWTClaimsSet으로부터 ParsedToken을 생성합니다.
+   */
+  public static ParsedToken from(JWTClaimsSet claims) throws ParseException {
+    return new ParsedToken(
+        claims.getJWTID(),
+        claims.getSubject(),
+        claims.getIssueTime(),
+        claims.getExpirationTime(),
+        claims.getStringClaim("role"),
+        claims.getClaims());
+  }
+}

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProvider.java
@@ -22,9 +22,7 @@ public class JwtTokenProvider {
 
   private final TokenBuilderFactory tokenBuilderFactory;
   private final SignedTokenFactory signedTokenFactory;
-  private final TokenParser tokenParser;
   private final TokenValidator tokenValidator;
-  private final AuthenticationBuilder authenticationBuilder;
   private final JWSVerifier verifier;
 
   public String generateAccessToken(Object subject, Object authorities) {
@@ -39,9 +37,9 @@ public class JwtTokenProvider {
 
   public Authentication getAuthentication(String token) {
     tokenValidator.validateSignature(token, verifier);
-    ParsedToken parsedToken = tokenParser.parse(token);
+    ParsedToken parsedToken = TokenParser.parse(token);
     tokenValidator.validateExpiration(parsedToken);
-    return authenticationBuilder.buildAuthentication(parsedToken, token);
+    return AuthenticationBuilder.buildAuthentication(parsedToken, token);
   }
 
   public void validate(String token) {
@@ -49,13 +47,13 @@ public class JwtTokenProvider {
   }
 
   public String parseJti(String token) {
-    ParsedToken parsedToken = tokenParser.parse(token);
-    return tokenParser.parseJti(parsedToken);
+    ParsedToken parsedToken = TokenParser.parse(token);
+    return TokenParser.parseJti(parsedToken);
   }
 
   public Instant parseIssueTime(String token) {
-    ParsedToken parsedToken = tokenParser.parse(token);
-    return tokenParser.parseIssueTime(parsedToken);
+    ParsedToken parsedToken = TokenParser.parse(token);
+    return TokenParser.parseIssueTime(parsedToken);
   }
 
   public String generateGuestToken(String provider, String providerId) {
@@ -64,7 +62,7 @@ public class JwtTokenProvider {
   }
 
   public String parseProvider(String token, String key) {
-    ParsedToken parsedToken = tokenParser.parse(token);
-    return tokenParser.parseClaim(parsedToken, key);
+    ParsedToken parsedToken = TokenParser.parse(token);
+    return TokenParser.parseClaim(parsedToken, key);
   }
 }

--- a/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProvider.java
@@ -1,211 +1,70 @@
 package io.github.metdaisy.amaazon.global.security.jwt.provider;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Supplier;
 import org.springframework.modulith.NamedInterface;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.JWSVerifier;
-import com.nimbusds.jose.crypto.MACSigner;
-import com.nimbusds.jose.crypto.MACVerifier;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
-import io.github.metdaisy.amaazon.common.exception.AmaazonException;
-import io.github.metdaisy.amaazon.global.security.jwt.config.JwtProperties;
-import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
-import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.builder.AuthenticationBuilder;
+import io.github.metdaisy.amaazon.global.security.jwt.builder.SignedTokenFactory;
+import io.github.metdaisy.amaazon.global.security.jwt.builder.TokenBuilderFactory;
+import io.github.metdaisy.amaazon.global.security.jwt.builder.TokenParser;
+import io.github.metdaisy.amaazon.global.security.jwt.builder.TokenValidator;
+import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @NamedInterface("jwt")
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtTokenProvider {
 
-  private final String authoritiesKey = "role";
-  private final JwtProperties jwtProperties;
-  private final JWSSigner signer;
+  private final TokenBuilderFactory tokenBuilderFactory;
+  private final SignedTokenFactory signedTokenFactory;
+  private final TokenParser tokenParser;
+  private final TokenValidator tokenValidator;
+  private final AuthenticationBuilder authenticationBuilder;
   private final JWSVerifier verifier;
-  private final JWSHeader header;
-
-  public JwtTokenProvider(JwtProperties jwtProperties) throws JOSEException {
-    this.jwtProperties = jwtProperties;
-    byte[] secretBytes = jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8);
-    this.signer = new MACSigner(secretBytes);
-    this.verifier = new MACVerifier(secretBytes);
-    this.header = new JWSHeader(JWSAlgorithm.HS256);
-  }
 
   public String generateAccessToken(Object subject, Object authorities) {
-    return buildToken(subject.toString(), authorities.toString(), getAccessTokenExpiration());
+    var claims = tokenBuilderFactory.buildAccessTokenClaims(subject.toString(), authorities.toString());
+    return signedTokenFactory.sign(claims);
   }
 
   public String generateRefreshToken(Object subject) {
-    return buildToken(subject.toString(), null, getRefreshTokenExpiration());
+    var claims = tokenBuilderFactory.buildRefreshTokenClaims(subject.toString());
+    return signedTokenFactory.sign(claims);
   }
 
   public Authentication getAuthentication(String token) {
-    SignedJWT signedJWT = getOrThrow(() -> SignedJWT.parse(token),
-        () -> new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, Map.of("refreshToken", token)));
-    JWTClaimsSet claims = getOrThrow(signedJWT::getJWTClaimsSet,
-        () -> new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "payload 파싱할 수 없습니다."));
-    String authClaim = getOrThrow(() -> claims.getStringClaim(authoritiesKey),
-        () -> new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED,
-            "payload 에서 role 을 파싱할 수 없습니다."));
-
-    if (!StringUtils.hasText(authClaim)) {
-      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "payload 에서 role 을 찾을 수 없습니다.");
-    }
-
-    Collection<? extends GrantedAuthority> authorities = parseAuthorities(authClaim);
-    UserDetails principal = new User(claims.getSubject(), "", authorities);
-    return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    tokenValidator.validateSignature(token, verifier);
+    ParsedToken parsedToken = tokenParser.parse(token);
+    tokenValidator.validateExpiration(parsedToken);
+    return authenticationBuilder.buildAuthentication(parsedToken, token);
   }
 
   public void validate(String token) {
-    SignedJWT signedJWT = getOrThrow(() -> SignedJWT.parse(token),
-        () -> new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, Map.of("refreshToken", token)));
-
-    boolean verified = getOrThrow(() -> signedJWT.verify(verifier),
-        () -> new JwtException(JwtErrorCode.VERIFICATION_FAILED));
-
-    if (!verified) {
-      throw new JwtException(JwtErrorCode.INVALID_SIGNATURE);
-    }
-
-    Date expirationTime = getOrThrow(() -> signedJWT.getJWTClaimsSet().getExpirationTime(),
-        () -> new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "claim 파싱을 할 수 없습니다."));
-    if (expirationTime == null) {
-      throw new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "토큰 유효기간을 찾을 수 없습니다.");
-    }
-    if (expirationTime.before(new Date())) {
-      throw new JwtException(JwtErrorCode.TOKEN_EXPIRED);
-    }
+    tokenValidator.validate(token, verifier);
   }
 
   public String parseJti(String token) {
-    JWTClaimsSet claimsSet = getJwtClaimsSet(token);
-    return getOrThrow(claimsSet::getJWTID, () -> new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED,
-        Map.of("token", token, "detailMessage", "jti 를 찾을 수 없습니다.")));
+    ParsedToken parsedToken = tokenParser.parse(token);
+    return tokenParser.parseJti(parsedToken);
   }
 
   public Instant parseIssueTime(String token) {
-    JWTClaimsSet claimsSet = getJwtClaimsSet(token);
-    return Instant.ofEpochSecond(claimsSet.getIssueTime().getTime());
+    ParsedToken parsedToken = tokenParser.parse(token);
+    return tokenParser.parseIssueTime(parsedToken);
   }
 
   public String generateGuestToken(String provider, String providerId) {
-    long now = System.currentTimeMillis();
-    long expirationMillis = getGuestTokenExpiration();
-
-    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
-            .jwtID(UUID.randomUUID().toString())
-            .claim("provider", provider)
-            .claim("providerId", providerId)
-            .issueTime(new Date(now))
-            .expirationTime(new Date(now + expirationMillis))
-            .build();
-
-    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
-    runOrThrow(() -> signedJWT.sign(signer),
-            () -> new JwtException(JwtErrorCode.SIGN_FAILED));
-    return signedJWT.serialize();
+    var claims = tokenBuilderFactory.buildGuestTokenClaims(provider, providerId);
+    return signedTokenFactory.sign(claims);
   }
 
   public String parseProvider(String token, String key) {
-    return getOrThrow(() -> getJwtClaimsSet(token).getClaimAsString(key),
-            () -> new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, "provider 를 찾을 수 없습니다."));
+    ParsedToken parsedToken = tokenParser.parse(token);
+    return tokenParser.parseClaim(parsedToken, key);
   }
-
-  private String buildToken(String subject, String authorities, long expirationMillis) {
-    long now = System.currentTimeMillis();
-    JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
-        .jwtID(UUID.randomUUID().toString())
-        .subject(subject)
-        .issueTime(new Date(now))
-        .expirationTime(new Date(now + expirationMillis));
-
-    if (StringUtils.hasText(authorities)) {
-      builder.claim(authoritiesKey, authorities);
-    }
-
-    SignedJWT signedJWT = new SignedJWT(header, builder.build());
-    runOrThrow(() -> signedJWT.sign(signer),
-        () -> new JwtException(JwtErrorCode.SIGN_FAILED));
-    return signedJWT.serialize();
-  }
-
-  private <T> T getOrThrow(JwtCheckedExceptionSupplier<T> supplier,
-      Supplier<? extends AmaazonException> exceptionSupplier) {
-    try {
-      return supplier.get();
-    } catch (Exception e) {
-      AmaazonException exception = exceptionSupplier.get();
-      log.error(exception.toString(), e);
-      throw exception;
-    }
-  }
-
-  private void runOrThrow(JwtCheckedExceptionRunnable runnable,
-      Supplier<? extends AmaazonException> exceptionSupplier) {
-    try {
-      runnable.run();
-    } catch (Exception e) {
-      AmaazonException exception = exceptionSupplier.get();
-      log.error(exception.toString(), e);
-      throw exception;
-    }
-  }
-
-  @FunctionalInterface
-  private interface JwtCheckedExceptionSupplier<T> {
-
-    T get() throws Exception;
-  }
-
-  @FunctionalInterface
-  private interface JwtCheckedExceptionRunnable {
-
-    void run() throws Exception;
-  }
-
-  private long getAccessTokenExpiration() {
-    return jwtProperties.accessTokenExpiration() * 1000;
-  }
-
-  private long getRefreshTokenExpiration() {
-    return jwtProperties.refreshTokenExpiration() * 1000;
-  }
-
-  private long getGuestTokenExpiration() {
-    return jwtProperties.guestTokenExpiration();
-  }
-
-  private Collection<? extends GrantedAuthority> parseAuthorities(String authClaim) {
-    return Arrays.stream(authClaim.split(","))
-        .map(String::toUpperCase)
-        .map(SimpleGrantedAuthority::new)
-        .toList();
-  }
-
-  private JWTClaimsSet getJwtClaimsSet(String token) {
-    return getOrThrow(() -> SignedJWT.parse(token).getJWTClaimsSet(),
-        () -> new JwtException(JwtErrorCode.TOKEN_PARSE_FAILED, Map.of("jwtToken", token)));
-  }
-
 }

--- a/src/test/java/io/github/metdaisy/amaazon/AmaazonApplicationTests.java
+++ b/src/test/java/io/github/metdaisy/amaazon/AmaazonApplicationTests.java
@@ -1,0 +1,18 @@
+package io.github.metdaisy.amaazon;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class AmaazonApplicationTests {
+
+  @Test
+  void contextLoads() {
+    // 컨텍스트 정상 로드 확인
+  }
+
+}

--- a/src/test/java/io/github/metdaisy/amaazon/TestcontainersConfiguration.java
+++ b/src/test/java/io/github/metdaisy/amaazon/TestcontainersConfiguration.java
@@ -1,0 +1,20 @@
+package io.github.metdaisy.amaazon;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfiguration {
+
+  @Bean
+  @ServiceConnection
+  public PostgreSQLContainer<?> postgresContainer() {
+    return new PostgreSQLContainer<>(DockerImageName.parse("postgres:17-alpine"))
+        .withDatabaseName("amaazon_test")
+        .withUsername("test")
+        .withPassword("test");
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/handler/AuthEventHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/handler/AuthEventHandlerTest.java
@@ -1,0 +1,34 @@
+package io.github.metdaisy.amaazon.auth.application.handler;
+
+import static org.mockito.Mockito.verify;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import io.github.metdaisy.amaazon.auth.application.service.AuthService;
+import io.github.metdaisy.amaazon.user.domain.event.UserCreatedEvent;
+
+@ExtendWith(MockitoExtension.class)
+class AuthEventHandlerTest {
+
+  @Mock
+  private AuthService authService;
+
+  @InjectMocks
+  private AuthEventHandler handler;
+
+  @Test
+  @DisplayName("handle UserCreatedEvent successfully")
+  void handle() {
+    UUID userId = UUID.randomUUID();
+    UserCreatedEvent event = new UserCreatedEvent(userId, "test@test.com", "password");
+
+    handler.handle(event);
+
+    verify(authService).create(userId, "test@test.com", "password");
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/handler/BlacklistEventHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/handler/BlacklistEventHandlerTest.java
@@ -1,0 +1,48 @@
+package io.github.metdaisy.amaazon.auth.application.handler;
+
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import io.github.metdaisy.amaazon.auth.application.service.BlacklistService;
+import io.github.metdaisy.amaazon.global.security.jwt.event.BlacklistTokenCreatedEvent;
+import io.github.metdaisy.amaazon.global.security.jwt.event.BlacklistUserCreatedEvent;
+
+@ExtendWith(MockitoExtension.class)
+class BlacklistEventHandlerTest {
+
+  @Mock
+  private BlacklistService blacklistService;
+
+  @InjectMocks
+  private BlacklistEventHandler handler;
+
+  @Test
+  @DisplayName("handle BlacklistTokenCreatedEvent")
+  void handleToken() {
+    Instant now = Instant.now();
+    BlacklistTokenCreatedEvent event = new BlacklistTokenCreatedEvent("jti-123", now);
+
+    handler.handle(event);
+
+    verify(blacklistService).createBlacklistToken("jti-123", now);
+  }
+
+  @Test
+  @DisplayName("handle BlacklistUserCreatedEvent")
+  void handleUser() {
+    UUID userId = UUID.randomUUID();
+    Instant now = Instant.now();
+    BlacklistUserCreatedEvent event = new BlacklistUserCreatedEvent(userId, now);
+
+    handler.handle(event);
+
+    verify(blacklistService).createBlacklistUser(userId, now);
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/handler/BlacklistInitializerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/handler/BlacklistInitializerTest.java
@@ -1,0 +1,82 @@
+package io.github.metdaisy.amaazon.auth.application.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.ScrollPosition;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Window;
+import io.github.metdaisy.amaazon.auth.domain.entity.BlacklistToken;
+import io.github.metdaisy.amaazon.auth.domain.entity.BlacklistUser;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistTokenRepository;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistUserRepository;
+import io.github.metdaisy.amaazon.global.security.jwt.registry.BlacklistRegistry;
+
+@ExtendWith(MockitoExtension.class)
+class BlacklistInitializerTest {
+
+  @Mock
+  private BlacklistRegistry registry;
+
+  @Mock
+  private BlacklistTokenRepository blacklistTokenRepository;
+
+  @Mock
+  private BlacklistUserRepository blacklistUserRepository;
+
+  @InjectMocks
+  private BlacklistInitializer initializer;
+
+  @Test
+  @DisplayName("handle ApplicationReadyEvent processes chunks correctly")
+  @SuppressWarnings("unchecked")
+  void handle() {
+    // given
+    Instant now = Instant.now();
+    BlacklistToken token = BlacklistToken.of("token-123", now);
+    Window<BlacklistToken> tokenWindow = mock(Window.class);
+    when(tokenWindow.isEmpty()).thenReturn(false);
+    when(tokenWindow.hasNext()).thenReturn(false);
+    doAnswer(i -> {
+      Consumer<BlacklistToken> c = i.getArgument(0);
+      c.accept(token);
+      return null;
+    }).when(tokenWindow).forEach(any());
+
+    when(blacklistTokenRepository.findTop1000By(any(ScrollPosition.class), any(Sort.class)))
+        .thenReturn(tokenWindow);
+
+    UUID userId = UUID.randomUUID();
+    BlacklistUser user = BlacklistUser.of(userId, now);
+    Window<BlacklistUser> userWindow = mock(Window.class);
+    when(userWindow.isEmpty()).thenReturn(false);
+    when(userWindow.hasNext()).thenReturn(false);
+    doAnswer(i -> {
+      Consumer<BlacklistUser> c = i.getArgument(0);
+      c.accept(user);
+      return null;
+    }).when(userWindow).forEach(any());
+
+    when(blacklistUserRepository.findTop1000By(any(ScrollPosition.class), any(Sort.class)))
+        .thenReturn(userWindow);
+
+    // when
+    initializer.handle();
+
+    // then
+    verify(registry).blacklistToken("token-123", now);
+    verify(registry).blacklistUser(userId, now);
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/handler/JwtEventHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/handler/JwtEventHandlerTest.java
@@ -1,0 +1,36 @@
+package io.github.metdaisy.amaazon.auth.application.handler;
+
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import io.github.metdaisy.amaazon.auth.application.event.JwtTokenCompromisedEvent;
+import io.github.metdaisy.amaazon.global.security.jwt.registry.BlacklistRegistry;
+
+@ExtendWith(MockitoExtension.class)
+class JwtEventHandlerTest {
+
+  @Mock
+  private BlacklistRegistry registry;
+
+  @InjectMocks
+  private JwtEventHandler handler;
+
+  @Test
+  @DisplayName("handle JwtTokenCompromisedEvent")
+  void handle() {
+    UUID userId = UUID.randomUUID();
+    Instant now = Instant.now();
+    JwtTokenCompromisedEvent event = new JwtTokenCompromisedEvent(userId, now);
+
+    handler.handle(event);
+
+    verify(registry).blacklistUser(userId, now);
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistCleanupSchedulerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistCleanupSchedulerTest.java
@@ -1,0 +1,60 @@
+package io.github.metdaisy.amaazon.auth.application.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistTokenRepository;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistUserRepository;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class BlacklistCleanupSchedulerTest {
+
+  @Mock
+  private BlacklistTokenRepository blacklistTokenRepository;
+
+  @Mock
+  private BlacklistUserRepository blacklistUserRepository;
+
+  @InjectMocks
+  private BlacklistScheduler blacklistScheduler;
+
+  @Test
+  @DisplayName("cleanup_success")
+  void cleanup_success() {
+    // given
+    Instant now = Instant.now();
+
+    // when
+    blacklistScheduler.cleanupBlacklistToken();
+
+    // then
+    verify(blacklistTokenRepository).deleteByExpiredAtLessThanEqual(now);
+  }
+
+  @Test
+  @DisplayName("cleanup_failure_exception")
+  void cleanup_failure_exception() {
+    // given
+    doThrow(new RuntimeException("DB error")).when(blacklistTokenRepository)
+        .deleteByExpiredAtLessThanEqual(any(Instant.class));
+
+    // when
+    // scheduler catches exception and logs, does not throw
+    blacklistScheduler.cleanupBlacklistToken();
+
+    // then
+    // No exception should be thrown, scheduler handles it internally
+    verify(blacklistTokenRepository).deleteByExpiredAtLessThanEqual(any(Instant.class));
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistCleanupSchedulerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistCleanupSchedulerTest.java
@@ -1,21 +1,19 @@
 package io.github.metdaisy.amaazon.auth.application.scheduler;
 
-import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import java.time.Instant;
+import java.time.Clock;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistTokenRepository;
 import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistUserRepository;
-
-import java.time.Instant;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class BlacklistCleanupSchedulerTest {
@@ -26,14 +24,21 @@ class BlacklistCleanupSchedulerTest {
   @Mock
   private BlacklistUserRepository blacklistUserRepository;
 
-  @InjectMocks
+  private Clock clock;
+
   private BlacklistScheduler blacklistScheduler;
+
+  @BeforeEach
+  void setUp() {
+    clock = Clock.fixed(Instant.parse("2026-07-30T10:00:00Z"), ZoneId.of("UTC"));
+    blacklistScheduler = new BlacklistScheduler(blacklistTokenRepository, blacklistUserRepository, clock);
+  }
 
   @Test
   @DisplayName("cleanup_success")
   void cleanup_success() {
     // given
-    Instant now = Instant.now();
+    Instant now = Instant.now(clock);
 
     // when
     blacklistScheduler.cleanupBlacklistToken();

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistSchedulerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistSchedulerTest.java
@@ -3,18 +3,20 @@ package io.github.metdaisy.amaazon.auth.application.scheduler;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-
-import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistTokenRepository;
-import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistUserRepository;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistTokenRepository;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistUserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class BlacklistSchedulerTest {
@@ -24,6 +26,9 @@ class BlacklistSchedulerTest {
 
   @Mock
   private BlacklistUserRepository blacklistUserRepository;
+
+  @Spy
+  private Clock clock = Clock.fixed(Instant.parse("2026-07-30T10:00:00Z"), ZoneId.of("UTC"));
 
   @InjectMocks
   private BlacklistScheduler scheduler;
@@ -43,8 +48,9 @@ class BlacklistSchedulerTest {
   @Test
   @DisplayName("cleanupBlacklistToken handles exception")
   void cleanupBlacklistToken_exception() {
-    doThrow(new RuntimeException("DB error")).when(blacklistTokenRepository).deleteByExpiredAtLessThanEqual(any(Instant.class));
-    
+    doThrow(new RuntimeException("DB error")).when(blacklistTokenRepository)
+        .deleteByExpiredAtLessThanEqual(any(Instant.class));
+
     // Should not throw
     scheduler.cleanupBlacklistToken();
     verify(blacklistTokenRepository).deleteByExpiredAtLessThanEqual(any(Instant.class));
@@ -60,8 +66,9 @@ class BlacklistSchedulerTest {
   @Test
   @DisplayName("cleanupBlacklistUser handles exception")
   void cleanupBlacklistUser_exception() {
-    doThrow(new RuntimeException("DB error")).when(blacklistUserRepository).deleteByCompromisedAtLessThanEqual(any(Instant.class));
-    
+    doThrow(new RuntimeException("DB error")).when(blacklistUserRepository)
+        .deleteByCompromisedAtLessThanEqual(any(Instant.class));
+
     // Should not throw
     scheduler.cleanupBlacklistUser();
     verify(blacklistUserRepository).deleteByCompromisedAtLessThanEqual(any(Instant.class));

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistSchedulerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/scheduler/BlacklistSchedulerTest.java
@@ -1,0 +1,69 @@
+package io.github.metdaisy.amaazon.auth.application.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistTokenRepository;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistUserRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BlacklistSchedulerTest {
+
+  @Mock
+  private BlacklistTokenRepository blacklistTokenRepository;
+
+  @Mock
+  private BlacklistUserRepository blacklistUserRepository;
+
+  @InjectMocks
+  private BlacklistScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(scheduler, "refreshTokenExpiration", 3600L);
+  }
+
+  @Test
+  @DisplayName("cleanupBlacklistToken success")
+  void cleanupBlacklistToken() {
+    scheduler.cleanupBlacklistToken();
+    verify(blacklistTokenRepository).deleteByExpiredAtLessThanEqual(any(Instant.class));
+  }
+
+  @Test
+  @DisplayName("cleanupBlacklistToken handles exception")
+  void cleanupBlacklistToken_exception() {
+    doThrow(new RuntimeException("DB error")).when(blacklistTokenRepository).deleteByExpiredAtLessThanEqual(any(Instant.class));
+    
+    // Should not throw
+    scheduler.cleanupBlacklistToken();
+    verify(blacklistTokenRepository).deleteByExpiredAtLessThanEqual(any(Instant.class));
+  }
+
+  @Test
+  @DisplayName("cleanupBlacklistUser success")
+  void cleanupBlacklistUser() {
+    scheduler.cleanupBlacklistUser();
+    verify(blacklistUserRepository).deleteByCompromisedAtLessThanEqual(any(Instant.class));
+  }
+
+  @Test
+  @DisplayName("cleanupBlacklistUser handles exception")
+  void cleanupBlacklistUser_exception() {
+    doThrow(new RuntimeException("DB error")).when(blacklistUserRepository).deleteByCompromisedAtLessThanEqual(any(Instant.class));
+    
+    // Should not throw
+    scheduler.cleanupBlacklistUser();
+    verify(blacklistUserRepository).deleteByCompromisedAtLessThanEqual(any(Instant.class));
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/service/AuthBlacklistServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/service/AuthBlacklistServiceTest.java
@@ -1,0 +1,60 @@
+package io.github.metdaisy.amaazon.auth.application.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import io.github.metdaisy.amaazon.auth.domain.entity.BlacklistToken;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistTokenRepository;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistUserRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthBlacklistServiceTest {
+
+  @Mock
+  private BlacklistTokenRepository blacklistTokenRepository;
+
+  @Mock
+  private BlacklistUserRepository blacklistUserRepository;
+
+  @InjectMocks
+  private BlacklistService blacklistService;
+
+  @Test
+  @DisplayName("blacklist_success")
+  void blacklist_success() {
+    // given
+    String jti = "test-jti";
+    Instant expiredAt = Instant.now().plusSeconds(3600);
+
+    // when
+    blacklistService.createBlacklistToken(jti, expiredAt);
+
+    // then
+    verify(blacklistTokenRepository).save(any(BlacklistToken.class));
+  }
+
+  @Test
+  @DisplayName("blacklist_failure_alreadyBlacklisted")
+  void blacklist_failure_alreadyBlacklisted() {
+    // given
+    String jti = "duplicate-jti";
+    Instant expiredAt = Instant.now().plusSeconds(3600);
+    doThrow(new RuntimeException("Duplicate entry")).when(blacklistTokenRepository)
+        .save(any(BlacklistToken.class));
+
+    // when & then
+    try {
+      blacklistService.createBlacklistToken(jti, expiredAt);
+    } catch (Exception e) {
+      // Exception is expected due to duplicate
+    }
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/service/AuthServiceTest.java
@@ -1,0 +1,81 @@
+package io.github.metdaisy.amaazon.auth.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.github.metdaisy.amaazon.auth.application.port.out.AuthUserPort;
+import io.github.metdaisy.amaazon.auth.domain.entity.SocialCredential;
+import io.github.metdaisy.amaazon.auth.domain.entity.UserCredential;
+import io.github.metdaisy.amaazon.auth.domain.exception.AuthException;
+import io.github.metdaisy.amaazon.auth.domain.repository.SocialCredentialRepository;
+import io.github.metdaisy.amaazon.auth.domain.repository.UserCredentialRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+  @Mock
+  private UserCredentialRepository repository;
+  @Mock
+  private SocialCredentialRepository socialRepository;
+  @Mock
+  private PasswordEncoder passwordEncoder;
+  @Mock
+  private AuthUserPort userPort;
+
+  @InjectMocks
+  private AuthService authService;
+
+  @Test
+  @DisplayName("create successfully")
+  void create() {
+    UUID userId = UUID.randomUUID();
+    given(repository.existsByEmail("test@test.com")).willReturn(false);
+    given(passwordEncoder.encode("password")).willReturn("encoded");
+
+    authService.create(userId, "test@test.com", "password");
+
+    verify(repository).save(any(UserCredential.class));
+  }
+
+  @Test
+  @DisplayName("create fails when email exists")
+  void create_fail_emailExists() {
+    UUID userId = UUID.randomUUID();
+    given(repository.existsByEmail("test@test.com")).willReturn(true);
+
+    assertThrows(AuthException.class, () -> authService.create(userId, "test@test.com", "password"));
+    verify(repository, never()).save(any(UserCredential.class));
+  }
+
+  @Test
+  @DisplayName("createSocial successfully")
+  void createSocial() {
+    UUID userId = UUID.randomUUID();
+    given(userPort.existsUser(userId)).willReturn(false);
+
+    authService.createSocial(userId, "google", "123");
+
+    verify(socialRepository).save(any(SocialCredential.class));
+  }
+
+  @Test
+  @DisplayName("createSocial fails when user not found")
+  void createSocial_fail_userNotFound() {
+    UUID userId = UUID.randomUUID();
+    given(userPort.existsUser(userId)).willReturn(true);
+
+    assertThrows(AuthException.class, () -> authService.createSocial(userId, "google", "123"));
+    verify(socialRepository, never()).save(any(SocialCredential.class));
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/service/AuthServiceTest.java
@@ -1,6 +1,6 @@
 package io.github.metdaisy.amaazon.auth.application.service;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -54,7 +54,8 @@ class AuthServiceTest {
     UUID userId = UUID.randomUUID();
     given(repository.existsByEmail("test@test.com")).willReturn(true);
 
-    assertThrows(AuthException.class, () -> authService.create(userId, "test@test.com", "password"));
+    assertThatThrownBy(() -> authService.create(userId, "test@test.com", "password"))
+        .isInstanceOf(AuthException.class);
     verify(repository, never()).save(any(UserCredential.class));
   }
 
@@ -75,7 +76,8 @@ class AuthServiceTest {
     UUID userId = UUID.randomUUID();
     given(userPort.existsUser(userId)).willReturn(true);
 
-    assertThrows(AuthException.class, () -> authService.createSocial(userId, "google", "123"));
+    assertThatThrownBy(() -> authService.createSocial(userId, "google", "123"))
+        .isInstanceOf(AuthException.class);
     verify(socialRepository, never()).save(any(SocialCredential.class));
   }
 }

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/service/AuthTokenServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/service/AuthTokenServiceTest.java
@@ -1,0 +1,132 @@
+package io.github.metdaisy.amaazon.auth.application.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import io.github.metdaisy.amaazon.auth.application.dto.AuthUserDto;
+import io.github.metdaisy.amaazon.auth.application.dto.JwtLoginDto;
+import io.github.metdaisy.amaazon.auth.application.port.out.AuthUserPort;
+import io.github.metdaisy.amaazon.auth.domain.entity.RefreshToken;
+import io.github.metdaisy.amaazon.auth.domain.exception.AuthErrorCode;
+import io.github.metdaisy.amaazon.auth.domain.exception.AuthException;
+import io.github.metdaisy.amaazon.auth.domain.repository.RefreshTokenRepository;
+import io.github.metdaisy.amaazon.global.security.jwt.config.JwtProperties;
+import io.github.metdaisy.amaazon.global.security.jwt.provider.JwtTokenProvider;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthTokenServiceTest {
+
+  @Mock
+  private RefreshTokenRepository repository;
+
+  @Mock
+  private AuthUserPort userPort;
+
+  @Mock
+  private JwtTokenProvider provider;
+
+  @Mock
+  private JwtProperties properties;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+
+  @InjectMocks
+  private AuthTokenService authTokenService;
+
+  @Test
+  @DisplayName("reissue_success")
+  void reissue_success() {
+    // given
+    String token = "valid-refresh-token";
+    String jti = "test-jti";
+    UUID userId = UUID.randomUUID();
+    AuthUserDto userDto = new AuthUserDto(userId, "USER");
+    JwtLoginDto loginDto = new JwtLoginDto(userId, "new-access-token", "new-refresh-token");
+
+    RefreshToken refreshToken = RefreshToken.of(userId, "device-1", jti, Instant.now().plusSeconds(3600));
+
+    doNothing().when(provider).validate(token);
+    given(provider.parseJti(token)).willReturn(jti);
+    given(repository.findByToken(jti)).willReturn(Optional.of(refreshToken));
+    given(userPort.loadUser(userId)).willReturn(Optional.of(userDto));
+    given(provider.generateAccessToken(userId, "USER")).willReturn("new-access-token");
+    given(provider.generateRefreshToken(userId)).willReturn("new-refresh-token");
+    given(provider.parseJti("new-refresh-token")).willReturn("new-jti");
+    given(properties.refreshTokenExpiration()).willReturn(3600L);
+
+    // when
+    JwtLoginDto result = authTokenService.reissue(token);
+
+    // then
+    assertThat(result).isEqualTo(loginDto);
+    assertThat(result.accessToken()).isEqualTo("new-access-token");
+    assertThat(result.refreshToken()).isEqualTo("new-refresh-token");
+    verify(repository).findByToken(jti);
+  }
+
+  @Test
+  @DisplayName("reissue_failure_invalidToken")
+  void reissue_failure_invalidToken() {
+    // given
+    String token = "invalid-refresh-token";
+    doThrow(new AuthException(AuthErrorCode.TOKEN_EXPIRED, Map.of("token", token))).when(provider).validate(token);
+
+    // when & then
+    assertThatThrownBy(() -> authTokenService.reissue(token))
+        .isInstanceOf(AuthException.class)
+        .hasMessageContaining("만료된 토큰입니다");
+  }
+
+  @Test
+  @DisplayName("create_success")
+  void create_success() {
+    // given
+    UUID userId = UUID.randomUUID();
+    AuthUserDto userDto = new AuthUserDto(userId, "USER");
+    given(userPort.loadUser(userId)).willReturn(Optional.of(userDto));
+    given(provider.generateAccessToken(userId, "USER")).willReturn("access-token");
+    given(provider.generateRefreshToken(userId)).willReturn("refresh-token");
+    given(provider.parseJti("refresh-token")).willReturn("jti");
+    given(properties.refreshTokenExpiration()).willReturn(3600L);
+
+    // when
+    JwtLoginDto result = authTokenService.create(userId, "device-1");
+
+    // then
+    assertThat(result.accessToken()).isEqualTo("access-token");
+    assertThat(result.refreshToken()).isEqualTo("refresh-token");
+    verify(repository).save(any(RefreshToken.class));
+  }
+
+  @Test
+  @DisplayName("delete_success")
+  void delete_success() {
+    // given
+    String token = "refresh-token";
+    given(provider.parseJti(token)).willReturn("jti");
+
+    // when
+    authTokenService.delete(token);
+
+    // then
+    verify(repository).deleteByTokenDirectly("jti");
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/service/BlacklistServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/service/BlacklistServiceTest.java
@@ -1,0 +1,47 @@
+package io.github.metdaisy.amaazon.auth.application.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import io.github.metdaisy.amaazon.auth.domain.entity.BlacklistToken;
+import io.github.metdaisy.amaazon.auth.domain.entity.BlacklistUser;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistTokenRepository;
+import io.github.metdaisy.amaazon.auth.domain.repository.BlacklistUserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlacklistServiceTest {
+
+  @Mock
+  private BlacklistTokenRepository blacklistTokenRepository;
+  
+  @Mock
+  private BlacklistUserRepository blacklistUserRepository;
+
+  @InjectMocks
+  private BlacklistService blacklistService;
+
+  @Test
+  @DisplayName("createBlacklistToken")
+  void createBlacklistToken() {
+    Instant now = Instant.now();
+    blacklistService.createBlacklistToken("jti-123", now);
+    verify(blacklistTokenRepository).save(any(BlacklistToken.class));
+  }
+
+  @Test
+  @DisplayName("createBlacklistUser")
+  void createBlacklistUser() {
+    Instant now = Instant.now();
+    UUID userId = UUID.randomUUID();
+    blacklistService.createBlacklistUser(userId, now);
+    verify(blacklistUserRepository).save(any(BlacklistUser.class));
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/service/GuestTokenServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/service/GuestTokenServiceTest.java
@@ -1,0 +1,54 @@
+package io.github.metdaisy.amaazon.auth.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import io.github.metdaisy.amaazon.global.security.jwt.provider.JwtTokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+class GuestTokenServiceTest {
+
+  @Mock
+  private JwtTokenProvider jwtTokenProvider;
+
+  @InjectMocks
+  private GuestTokenService guestTokenService;
+
+  @Test
+  @DisplayName("create guest token")
+  void create() {
+    given(jwtTokenProvider.generateGuestToken("google", "123")).willReturn("guest-token");
+    String result = guestTokenService.create("google", "123");
+    assertEquals("guest-token", result);
+  }
+
+  @Test
+  @DisplayName("getProvider")
+  void getProvider() {
+    given(jwtTokenProvider.parseProvider("guest-token", "provider")).willReturn("google");
+    String result = guestTokenService.getProvider("guest-token");
+    assertEquals("google", result);
+  }
+
+  @Test
+  @DisplayName("getProviderId")
+  void getProviderId() {
+    given(jwtTokenProvider.parseProvider("guest-token", "providerId")).willReturn("123");
+    String result = guestTokenService.getProviderId("guest-token");
+    assertEquals("123", result);
+  }
+
+  @Test
+  @DisplayName("validate")
+  void validate() {
+    guestTokenService.validate("guest-token");
+    verify(jwtTokenProvider).validate("guest-token");
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/application/service/GuestTokenServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/application/service/GuestTokenServiceTest.java
@@ -1,6 +1,6 @@
 package io.github.metdaisy.amaazon.auth.application.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -26,7 +26,7 @@ class GuestTokenServiceTest {
   void create() {
     given(jwtTokenProvider.generateGuestToken("google", "123")).willReturn("guest-token");
     String result = guestTokenService.create("google", "123");
-    assertEquals("guest-token", result);
+    assertThat(result).isEqualTo("guest-token");
   }
 
   @Test
@@ -34,7 +34,7 @@ class GuestTokenServiceTest {
   void getProvider() {
     given(jwtTokenProvider.parseProvider("guest-token", "provider")).willReturn("google");
     String result = guestTokenService.getProvider("guest-token");
-    assertEquals("google", result);
+    assertThat(result).isEqualTo("google");
   }
 
   @Test
@@ -42,7 +42,7 @@ class GuestTokenServiceTest {
   void getProviderId() {
     given(jwtTokenProvider.parseProvider("guest-token", "providerId")).willReturn("123");
     String result = guestTokenService.getProviderId("guest-token");
-    assertEquals("123", result);
+    assertThat(result).isEqualTo("123");
   }
 
   @Test

--- a/src/test/java/io/github/metdaisy/amaazon/auth/infra/adapter/AuthUserAdapterTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/infra/adapter/AuthUserAdapterTest.java
@@ -1,0 +1,56 @@
+package io.github.metdaisy.amaazon.auth.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import io.github.metdaisy.amaazon.user.application.dto.UserDto;
+import io.github.metdaisy.amaazon.user.application.port.in.UserQueryApi;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthUserAdapterTest {
+
+  @Mock
+  private UserQueryApi userQueryApi;
+
+  @InjectMocks
+  private AuthUserAdapter authUserAdapter;
+
+  @Test
+  @DisplayName("loadUser_success")
+  void loadUser_success() {
+    // given
+    UUID userId = UUID.randomUUID();
+    UserDto userDto = new UserDto(userId, "USER");
+    given(userQueryApi.findById(userId)).willReturn(Optional.of(userDto));
+
+    // when
+    var result = authUserAdapter.loadUser(userId);
+
+    // then
+    assertThat(result).isPresent();
+    assertThat(result.get().id()).isEqualTo(userId);
+    assertThat(result.get().role()).isEqualTo("USER");
+  }
+
+  @Test
+  @DisplayName("loadUser_failure_mappingError")
+  void loadUser_failure_mappingError() {
+    // given
+    UUID userId = UUID.randomUUID();
+    given(userQueryApi.findById(userId)).willReturn(Optional.empty());
+
+    // when
+    var result = authUserAdapter.loadUser(userId);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/infra/security/FormUserDetailsServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/infra/security/FormUserDetailsServiceTest.java
@@ -1,0 +1,68 @@
+package io.github.metdaisy.amaazon.auth.infra.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import io.github.metdaisy.amaazon.auth.application.dto.AuthUserDto;
+import io.github.metdaisy.amaazon.auth.application.port.out.AuthUserPort;
+import io.github.metdaisy.amaazon.auth.domain.entity.UserCredential;
+import io.github.metdaisy.amaazon.auth.domain.exception.AuthException;
+import io.github.metdaisy.amaazon.auth.domain.repository.UserCredentialRepository;
+
+@ExtendWith(MockitoExtension.class)
+class FormUserDetailsServiceTest {
+
+  @Mock
+  private AuthUserPort userPort;
+
+  @Mock
+  private UserCredentialRepository repository;
+
+  @InjectMocks
+  private FormUserDetailsService formUserDetailsService;
+
+  @Test
+  @DisplayName("loadUserByUsername success")
+  void loadUserByUsername() {
+    UUID userId = UUID.randomUUID();
+    UserCredential credential = UserCredential.of(userId, "test@test.com", "password");
+    given(repository.findByEmail("test@test.com")).willReturn(Optional.of(credential));
+    
+    AuthUserDto userDto = new AuthUserDto(userId, "USER");
+    given(userPort.loadUser(userId)).willReturn(Optional.of(userDto));
+
+    UserDetails result = formUserDetailsService.loadUserByUsername("test@test.com");
+    
+    assertEquals(userId.toString(), result.getUsername());
+    assertEquals("password", result.getPassword());
+  }
+
+  @Test
+  @DisplayName("loadUserByUsername fails when email not found")
+  void loadUserByUsername_emailNotFound() {
+    given(repository.findByEmail("test@test.com")).willReturn(Optional.empty());
+
+    assertThrows(AuthException.class, () -> formUserDetailsService.loadUserByUsername("test@test.com"));
+  }
+
+  @Test
+  @DisplayName("loadUserByUsername fails when user not found")
+  void loadUserByUsername_userNotFound() {
+    UUID userId = UUID.randomUUID();
+    UserCredential credential = UserCredential.of(userId, "test@test.com", "password");
+    given(repository.findByEmail("test@test.com")).willReturn(Optional.of(credential));
+    given(userPort.loadUser(userId)).willReturn(Optional.empty());
+
+    assertThrows(AuthException.class, () -> formUserDetailsService.loadUserByUsername("test@test.com"));
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/infra/security/FormUserDetailsServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/infra/security/FormUserDetailsServiceTest.java
@@ -1,9 +1,8 @@
 package io.github.metdaisy.amaazon.auth.infra.security;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -37,14 +36,16 @@ class FormUserDetailsServiceTest {
     UUID userId = UUID.randomUUID();
     UserCredential credential = UserCredential.of(userId, "test@test.com", "password");
     given(repository.findByEmail("test@test.com")).willReturn(Optional.of(credential));
-    
+
     AuthUserDto userDto = new AuthUserDto(userId, "USER");
     given(userPort.loadUser(userId)).willReturn(Optional.of(userDto));
 
     UserDetails result = formUserDetailsService.loadUserByUsername("test@test.com");
-    
-    assertEquals(userId.toString(), result.getUsername());
-    assertEquals("password", result.getPassword());
+
+    assertThat(result.getUsername()).isEqualTo(userId.toString());
+    assertThat(result.getPassword()).isEqualTo("password");
+    assertThat(result.getAuthorities())
+        .anyMatch(a -> a.getAuthority().equals("ROLE_USER") || a.getAuthority().equals("USER"));
   }
 
   @Test
@@ -52,7 +53,8 @@ class FormUserDetailsServiceTest {
   void loadUserByUsername_emailNotFound() {
     given(repository.findByEmail("test@test.com")).willReturn(Optional.empty());
 
-    assertThrows(AuthException.class, () -> formUserDetailsService.loadUserByUsername("test@test.com"));
+    assertThatThrownBy(() -> formUserDetailsService.loadUserByUsername("test@test.com"))
+        .isInstanceOf(AuthException.class);
   }
 
   @Test
@@ -63,6 +65,7 @@ class FormUserDetailsServiceTest {
     given(repository.findByEmail("test@test.com")).willReturn(Optional.of(credential));
     given(userPort.loadUser(userId)).willReturn(Optional.empty());
 
-    assertThrows(AuthException.class, () -> formUserDetailsService.loadUserByUsername("test@test.com"));
+    assertThatThrownBy(() -> formUserDetailsService.loadUserByUsername("test@test.com"))
+        .isInstanceOf(AuthException.class);
   }
 }

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/controller/AuthControllerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/controller/AuthControllerTest.java
@@ -1,0 +1,104 @@
+package io.github.metdaisy.amaazon.auth.presentation.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.metdaisy.amaazon.global.exception.strategy.ExceptionStrategyFactory;
+import io.github.metdaisy.amaazon.global.security.constant.SecurityConstants;
+import io.github.metdaisy.amaazon.global.security.jwt.provider.JwtTokenProvider;
+import io.github.metdaisy.amaazon.global.security.jwt.registry.BlacklistRegistry;
+import jakarta.servlet.http.Cookie;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import io.github.metdaisy.amaazon.auth.application.dto.JwtLoginDto;
+import io.github.metdaisy.amaazon.auth.application.service.AuthTokenService;
+import io.github.metdaisy.amaazon.auth.presentation.constant.AuthWebConstants;
+import io.github.metdaisy.amaazon.auth.presentation.provider.AuthCookieProvider;
+import io.github.metdaisy.amaazon.global.exception.GlobalExceptionHandler;
+import io.github.metdaisy.amaazon.global.security.config.SecurityConfig;
+import io.github.metdaisy.amaazon.global.security.filter.JwtAuthenticationFilter;
+import io.github.metdaisy.amaazon.global.web.config.WebMvcConfig;
+
+@WebMvcTest(AuthController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class, JwtAuthenticationFilter.class, WebMvcConfig.class})
+@DisplayName("AuthController 테스트")
+class AuthControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean(name = "formLoginSuccessHandler")
+  private AuthenticationSuccessHandler formLoginSuccessHandler;
+
+  @MockitoBean
+  private AuthenticationFailureHandler loginFailureHandler;
+
+  @MockitoBean
+  private LogoutHandler logoutHandler;
+
+  @MockitoBean
+  private JwtTokenProvider jwtTokenProvider;
+
+  @MockitoBean
+  private BlacklistRegistry blacklistRegistry;
+
+  @MockitoBean
+  private ExceptionStrategyFactory exceptionStrategyFactory;
+
+  @MockitoBean
+  private AuthTokenService authTokenService;
+
+  @MockitoBean
+  private AuthCookieProvider authCookieProvider;
+
+  @Test
+  @DisplayName("refresh_success: 유효한 refresh token으로 재발급 성공")
+  void refresh_success() throws Exception {
+    // given
+    String refreshToken = "valid-refresh-token";
+    String newRefreshToken = "new-refresh-token";
+    String accessToken = "new-access-token";
+    UUID userId = UUID.randomUUID();
+
+    JwtLoginDto loginDto = new JwtLoginDto(userId, accessToken, newRefreshToken);
+    given(authTokenService.reissue(refreshToken)).willReturn(loginDto);
+    given(authCookieProvider.createRefreshTokenCookie(newRefreshToken)).willReturn(
+        ResponseCookie.from(AuthWebConstants.REFRESH_TOKEN, newRefreshToken)
+            .path("/")
+            .maxAge(Duration.ofSeconds(3600))
+            .httpOnly(true)
+            .build());
+
+    // when & then
+    mockMvc.perform(post(SecurityConstants.REFRESH_URL)
+        .cookie(new Cookie(AuthWebConstants.REFRESH_TOKEN, refreshToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(userId.toString()))
+        .andExpect(jsonPath("$.accessToken").value(accessToken))
+        .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("REFRESH_TOKEN")));
+  }
+
+  @Test
+  @DisplayName("refresh_failure_emptyToken: 빈 토큰 제공 시 401 반환")
+  void refresh_failure_emptyToken() throws Exception {
+    // given & when & then
+    mockMvc.perform(post(SecurityConstants.REFRESH_URL))
+        .andExpect(status().isUnauthorized());
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/FormLoginFailureHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/FormLoginFailureHandlerTest.java
@@ -1,0 +1,55 @@
+package io.github.metdaisy.amaazon.auth.presentation.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class FormLoginFailureHandlerTest {
+
+  @Mock
+  private ObjectMapper objectMapper;
+
+  @InjectMocks
+  private FormLoginFailureHandler formLoginFailureHandler;
+
+  @Test
+  @DisplayName("onAuthenticationFailure_success")
+  void onAuthenticationFailure_success() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AuthenticationException exception = new AuthenticationException("test") {};
+
+    // when
+    formLoginFailureHandler.onAuthenticationFailure(request, response, exception);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getContentType()).isEqualTo("application/json");
+  }
+
+  @Test
+  @DisplayName("onAuthenticationFailure_failure")
+  void onAuthenticationFailure_failure() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AuthenticationException exception = new AuthenticationException("test") {};
+
+    // when
+    formLoginFailureHandler.onAuthenticationFailure(request, response, exception);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(401);
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/FormLoginFailureHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/FormLoginFailureHandlerTest.java
@@ -1,22 +1,25 @@
 package io.github.metdaisy.amaazon.auth.presentation.handler;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
+import java.io.OutputStream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(MockitoExtension.class)
 class FormLoginFailureHandlerTest {
 
-  @Mock
+  @Spy
   private ObjectMapper objectMapper;
 
   @InjectMocks
@@ -36,20 +39,24 @@ class FormLoginFailureHandlerTest {
     // then
     assertThat(response.getStatus()).isEqualTo(401);
     assertThat(response.getContentType()).isEqualTo("application/json");
+    assertThat(response.getContentAsString()).contains("login failed");
   }
 
   @Test
-  @DisplayName("onAuthenticationFailure_failure")
+  @DisplayName("onAuthenticationFailure_failure (serialization error)")
   void onAuthenticationFailure_failure() throws Exception {
     // given
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
     AuthenticationException exception = new AuthenticationException("test") {};
+    willThrow(new java.io.IOException("serialize error"))
+            .given(objectMapper).writeValue(any(OutputStream.class), any());
 
     // when
     formLoginFailureHandler.onAuthenticationFailure(request, response, exception);
 
     // then
     assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getContentType()).isEqualTo("application/json");
   }
 }

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/FormLoginFailureHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/FormLoginFailureHandlerTest.java
@@ -1,11 +1,13 @@
 package io.github.metdaisy.amaazon.auth.presentation.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.OutputStream;
+import java.io.IOException;
+import java.io.Writer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +33,8 @@ class FormLoginFailureHandlerTest {
     // given
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
-    AuthenticationException exception = new AuthenticationException("test") {};
+    AuthenticationException exception = new AuthenticationException("test") {
+    };
 
     // when
     formLoginFailureHandler.onAuthenticationFailure(request, response, exception);
@@ -49,13 +52,15 @@ class FormLoginFailureHandlerTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
     AuthenticationException exception = new AuthenticationException("test") {};
-    willThrow(new java.io.IOException("serialize error"))
-            .given(objectMapper).writeValue(any(OutputStream.class), any());
+    willThrow(new IOException("serialize error"))
+            .given(objectMapper).writeValue(any(Writer.class), any());
 
-    // when
-    formLoginFailureHandler.onAuthenticationFailure(request, response, exception);
+    // when & then
+    assertThatThrownBy(() ->
+            formLoginFailureHandler.onAuthenticationFailure(request, response, exception))
+            .isInstanceOf(IOException.class)
+            .hasMessage("serialize error");
 
-    // then
     assertThat(response.getStatus()).isEqualTo(401);
     assertThat(response.getContentType()).isEqualTo("application/json");
   }

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/FormLoginSuccessHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/FormLoginSuccessHandlerTest.java
@@ -1,0 +1,105 @@
+package io.github.metdaisy.amaazon.auth.presentation.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.PrintWriter;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.metdaisy.amaazon.auth.application.dto.JwtLoginDto;
+import io.github.metdaisy.amaazon.auth.application.service.AuthService;
+import io.github.metdaisy.amaazon.auth.application.service.AuthTokenService;
+import io.github.metdaisy.amaazon.auth.application.service.GuestTokenService;
+import io.github.metdaisy.amaazon.auth.presentation.constant.AuthWebConstants;
+import io.github.metdaisy.amaazon.auth.presentation.provider.AuthCookieProvider;
+import jakarta.servlet.http.Cookie;
+
+@ExtendWith(MockitoExtension.class)
+class FormLoginSuccessHandlerTest {
+
+  @Mock
+  private AuthTokenService authTokenService;
+  @Mock
+  private AuthCookieProvider authCookieProvider;
+  @Mock
+  private ObjectMapper mapper;
+  @Mock
+  private GuestTokenService guestTokenService;
+  @Mock
+  private AuthService authService;
+  @Mock
+  private Authentication authentication;
+
+  @InjectMocks
+  private FormLoginSuccessHandler handler;
+
+  @Test
+  @DisplayName("onAuthenticationSuccess: guest token cookie absent")
+  void onAuthenticationSuccess_noGuestToken() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(AuthWebConstants.HEADER_DEVICE_ID, "device-123");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    UUID userId = UUID.randomUUID();
+    given(authentication.getName()).willReturn(userId.toString());
+
+    JwtLoginDto loginDto = new JwtLoginDto(userId, "access", "refresh");
+    given(authTokenService.create(userId, "device-123")).willReturn(loginDto);
+    given(authCookieProvider.createRefreshTokenCookie("refresh"))
+        .willReturn(ResponseCookie.from(AuthWebConstants.REFRESH_TOKEN, "refresh").build());
+    given(authCookieProvider.createDeleteGuestTokenCookie())
+        .willReturn(ResponseCookie.from(AuthWebConstants.COOKIE_GUEST_TOKEN, "").build());
+
+    // when
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    verify(guestTokenService, never()).validate(anyString());
+    verify(authService, never()).createSocial(any(UUID.class), anyString(), anyString());
+    verify(mapper).writeValue(any(PrintWriter.class), any(JwtLoginDto.class));
+  }
+
+  @Test
+  @DisplayName("onAuthenticationSuccess: guest token cookie present")
+  void onAuthenticationSuccess_withGuestToken() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(AuthWebConstants.HEADER_DEVICE_ID, "device-123");
+    request.setCookies(new Cookie(AuthWebConstants.COOKIE_GUEST_TOKEN, "guest-token"));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    UUID userId = UUID.randomUUID();
+    given(authentication.getName()).willReturn(userId.toString());
+
+    JwtLoginDto loginDto = new JwtLoginDto(userId, "access", "refresh");
+    given(authTokenService.create(userId, "device-123")).willReturn(loginDto);
+    given(authCookieProvider.createRefreshTokenCookie("refresh"))
+        .willReturn(ResponseCookie.from(AuthWebConstants.REFRESH_TOKEN, "refresh").build());
+    given(authCookieProvider.createDeleteGuestTokenCookie())
+        .willReturn(ResponseCookie.from(AuthWebConstants.COOKIE_GUEST_TOKEN, "").build());
+
+    given(guestTokenService.getProvider("guest-token")).willReturn("google");
+    given(guestTokenService.getProviderId("guest-token")).willReturn("google-id");
+
+    // when
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    verify(guestTokenService).validate("guest-token");
+    verify(authService).createSocial(userId, "google", "google-id");
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/JwtLogoutHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/JwtLogoutHandlerTest.java
@@ -1,24 +1,22 @@
 package io.github.metdaisy.amaazon.auth.presentation.handler;
 
-import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import io.github.metdaisy.amaazon.auth.application.service.AuthTokenService;
 import io.github.metdaisy.amaazon.auth.presentation.constant.AuthWebConstants;
 import io.github.metdaisy.amaazon.auth.presentation.provider.AuthCookieProvider;
 import jakarta.servlet.http.Cookie;
-import org.springframework.http.ResponseCookie;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.core.Authentication;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class JwtLogoutHandlerTest {

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/JwtLogoutHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/JwtLogoutHandlerTest.java
@@ -48,6 +48,7 @@ class JwtLogoutHandlerTest {
     // then
     verify(authTokenService).delete("test-refresh-token");
     verify(authCookieProvider).createDeleteRefreshTokenCookie();
+    org.assertj.core.api.Assertions.assertThat(response.getHeader(org.springframework.http.HttpHeaders.SET_COOKIE)).isNotNull();
   }
 
   @Test
@@ -67,5 +68,6 @@ class JwtLogoutHandlerTest {
     // then
     verify(authTokenService, never()).delete(anyString());
     verify(authCookieProvider).createDeleteRefreshTokenCookie();
+    org.assertj.core.api.Assertions.assertThat(response.getHeader(org.springframework.http.HttpHeaders.SET_COOKIE)).isNotNull();
   }
 }

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/JwtLogoutHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/JwtLogoutHandlerTest.java
@@ -1,0 +1,73 @@
+package io.github.metdaisy.amaazon.auth.presentation.handler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import io.github.metdaisy.amaazon.auth.application.service.AuthTokenService;
+import io.github.metdaisy.amaazon.auth.presentation.constant.AuthWebConstants;
+import io.github.metdaisy.amaazon.auth.presentation.provider.AuthCookieProvider;
+import jakarta.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class JwtLogoutHandlerTest {
+
+  @Mock
+  private AuthTokenService authTokenService;
+
+  @Mock
+  private AuthCookieProvider authCookieProvider;
+
+  @InjectMocks
+  private JwtLogoutHandler jwtLogoutHandler;
+
+  @Test
+  @DisplayName("logout_success")
+  void logout_success() {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    Cookie cookie = new Cookie(AuthWebConstants.REFRESH_TOKEN, "test-refresh-token");
+    request.setCookies(cookie);
+
+    given(authCookieProvider.createDeleteRefreshTokenCookie())
+        .willReturn(ResponseCookie.from(AuthWebConstants.REFRESH_TOKEN, "").build());
+
+    // when
+    jwtLogoutHandler.logout(request, response, null);
+
+    // then
+    verify(authTokenService).delete("test-refresh-token");
+    verify(authCookieProvider).createDeleteRefreshTokenCookie();
+  }
+
+  @Test
+  @DisplayName("logout_failure_noCookie")
+  void logout_failure_noCookie() {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    // No cookie set
+
+    given(authCookieProvider.createDeleteRefreshTokenCookie())
+        .willReturn(ResponseCookie.from(AuthWebConstants.REFRESH_TOKEN, "").build());
+
+    // when
+    jwtLogoutHandler.logout(request, response, null);
+
+    // then
+    verify(authTokenService, never()).delete(anyString());
+    verify(authCookieProvider).createDeleteRefreshTokenCookie();
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/SocialLoginSuccessHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/SocialLoginSuccessHandlerTest.java
@@ -1,6 +1,6 @@
 package io.github.metdaisy.amaazon.auth.presentation.handler;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 import java.util.Collection;
@@ -65,7 +65,7 @@ class SocialLoginSuccessHandlerTest {
     handler.onAuthenticationSuccess(request, response, authentication);
 
     // then
-    assert Objects.equals(response.getRedirectedUrl(), AuthWebConstants.GUEST_REDIRECT_URL);
+    org.assertj.core.api.Assertions.assertThat(response.getRedirectedUrl()).isEqualTo(AuthWebConstants.GUEST_REDIRECT_URL);
   }
 
   @Test
@@ -93,7 +93,7 @@ class SocialLoginSuccessHandlerTest {
     handler.onAuthenticationSuccess(request, response, authentication);
 
     // then
-    assert Objects.equals(response.getRedirectedUrl(), AuthWebConstants.DEFAULT_SUCCESS_URL);
+    org.assertj.core.api.Assertions.assertThat(response.getRedirectedUrl()).isEqualTo(AuthWebConstants.DEFAULT_SUCCESS_URL);
   }
 
   @Test
@@ -108,6 +108,7 @@ class SocialLoginSuccessHandlerTest {
     given(authentication.getName()).willReturn(UUID.randomUUID().toString());
 
     // when & then
-    assertThrows(AuthException.class, () -> handler.onAuthenticationSuccess(request, response, authentication));
+    assertThatThrownBy(() -> handler.onAuthenticationSuccess(request, response, authentication))
+        .isInstanceOf(AuthException.class);
   }
 }

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/SocialLoginSuccessHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/SocialLoginSuccessHandlerTest.java
@@ -1,0 +1,115 @@
+package io.github.metdaisy.amaazon.auth.presentation.handler;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import io.github.metdaisy.amaazon.auth.application.dto.JwtLoginDto;
+import io.github.metdaisy.amaazon.auth.application.service.AuthTokenService;
+import io.github.metdaisy.amaazon.auth.application.service.GuestTokenService;
+import io.github.metdaisy.amaazon.auth.domain.exception.AuthException;
+import io.github.metdaisy.amaazon.auth.presentation.constant.AuthWebConstants;
+import io.github.metdaisy.amaazon.auth.presentation.provider.AuthCookieProvider;
+import jakarta.servlet.http.Cookie;
+
+@ExtendWith(MockitoExtension.class)
+class SocialLoginSuccessHandlerTest {
+
+  @Mock
+  private AuthTokenService authTokenService;
+  @Mock
+  private AuthCookieProvider authCookieProvider;
+  @Mock
+  private GuestTokenService guestTokenService;
+  @Mock
+  private Authentication authentication;
+
+  @InjectMocks
+  private SocialLoginSuccessHandler handler;
+
+  @Test
+  @DisplayName("onAuthenticationSuccess: guest user")
+  void onAuthenticationSuccess_guest() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    Collection authorities = List.of(new SimpleGrantedAuthority("ROLE_GUEST"));
+    given(authentication.getAuthorities()).willReturn(authorities);
+
+    OAuth2User oauth2User = new DefaultOAuth2User(authorities, Map.of("provider", "google", "providerId", "123"), "provider");
+    given(authentication.getPrincipal()).willReturn(oauth2User);
+    given(guestTokenService.create("google", "123")).willReturn("guest-token");
+    given(authCookieProvider.createGuestTokenCookie("guest-token"))
+        .willReturn(ResponseCookie.from(AuthWebConstants.COOKIE_GUEST_TOKEN, "guest-token").build());
+
+    // when
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    assert response.getRedirectedUrl().equals(AuthWebConstants.GUEST_REDIRECT_URL);
+  }
+
+  @Test
+  @DisplayName("onAuthenticationSuccess: normal user")
+  void onAuthenticationSuccess_normal() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(new Cookie(AuthWebConstants.COOKIE_DEVICE_ID, "device-123"));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    Collection authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    given(authentication.getAuthorities()).willReturn(authorities);
+    
+    UUID userId = UUID.randomUUID();
+    given(authentication.getName()).willReturn(userId.toString());
+
+    JwtLoginDto loginDto = new JwtLoginDto(userId, "access", "refresh");
+    given(authTokenService.create(userId, "device-123")).willReturn(loginDto);
+    given(authCookieProvider.createRefreshTokenCookie("refresh"))
+        .willReturn(ResponseCookie.from(AuthWebConstants.REFRESH_TOKEN, "refresh").build());
+    given(authCookieProvider.createDeleteDeviceIdCookie())
+        .willReturn(ResponseCookie.from(AuthWebConstants.COOKIE_DEVICE_ID, "").build());
+
+    // when
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    assert response.getRedirectedUrl().equals(AuthWebConstants.DEFAULT_SUCCESS_URL);
+  }
+
+  @Test
+  @DisplayName("onAuthenticationSuccess: normal user without device id throws exception")
+  void onAuthenticationSuccess_noDeviceId() {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    Collection authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    given(authentication.getAuthorities()).willReturn(authorities);
+    given(authentication.getName()).willReturn(UUID.randomUUID().toString());
+
+    // when & then
+    assertThrows(AuthException.class, () -> handler.onAuthenticationSuccess(request, response, authentication));
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/SocialLoginSuccessHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/SocialLoginSuccessHandlerTest.java
@@ -1,13 +1,9 @@
 package io.github.metdaisy.amaazon.auth.presentation.handler;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/SocialLoginSuccessHandlerTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/auth/presentation/handler/SocialLoginSuccessHandlerTest.java
@@ -3,12 +3,14 @@ package io.github.metdaisy.amaazon.auth.presentation.handler;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,8 +56,8 @@ class SocialLoginSuccessHandlerTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    Collection authorities = List.of(new SimpleGrantedAuthority("ROLE_GUEST"));
-    given(authentication.getAuthorities()).willReturn(authorities);
+    Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_GUEST"));
+    doReturn(authorities).when(authentication).getAuthorities();
 
     OAuth2User oauth2User = new DefaultOAuth2User(authorities, Map.of("provider", "google", "providerId", "123"), "provider");
     given(authentication.getPrincipal()).willReturn(oauth2User);
@@ -67,7 +69,7 @@ class SocialLoginSuccessHandlerTest {
     handler.onAuthenticationSuccess(request, response, authentication);
 
     // then
-    assert response.getRedirectedUrl().equals(AuthWebConstants.GUEST_REDIRECT_URL);
+    assert Objects.equals(response.getRedirectedUrl(), AuthWebConstants.GUEST_REDIRECT_URL);
   }
 
   @Test
@@ -78,8 +80,8 @@ class SocialLoginSuccessHandlerTest {
     request.setCookies(new Cookie(AuthWebConstants.COOKIE_DEVICE_ID, "device-123"));
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    Collection authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
-    given(authentication.getAuthorities()).willReturn(authorities);
+    Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    doReturn(authorities).when(authentication).getAuthorities();
     
     UUID userId = UUID.randomUUID();
     given(authentication.getName()).willReturn(userId.toString());
@@ -95,7 +97,7 @@ class SocialLoginSuccessHandlerTest {
     handler.onAuthenticationSuccess(request, response, authentication);
 
     // then
-    assert response.getRedirectedUrl().equals(AuthWebConstants.DEFAULT_SUCCESS_URL);
+    assert Objects.equals(response.getRedirectedUrl(), AuthWebConstants.DEFAULT_SUCCESS_URL);
   }
 
   @Test
@@ -105,8 +107,8 @@ class SocialLoginSuccessHandlerTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    Collection authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
-    given(authentication.getAuthorities()).willReturn(authorities);
+    Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    doReturn(authorities).when(authentication).getAuthorities();
     given(authentication.getName()).willReturn(UUID.randomUUID().toString());
 
     // when & then

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,181 @@
+package io.github.metdaisy.amaazon.global.security.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.provider.JwtTokenProvider;
+import io.github.metdaisy.amaazon.global.security.jwt.registry.BlacklistRegistry;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+  @Mock
+  private JwtTokenProvider tokenProvider;
+
+  @Mock
+  private BlacklistRegistry blacklistRegistry;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private FilterChain filterChain;
+
+  @Captor
+  private ArgumentCaptor<Authentication> authenticationCaptor;
+
+  private JwtAuthenticationFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    filter = new JwtAuthenticationFilter(tokenProvider, blacklistRegistry);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @DisplayName("필터 실행 - 성공: Authorization 헤더가 없으면 인증 없이 다음 필터로 전달된다")
+  @Test
+  void doFilter_noAuthHeader_passesThrough() throws ServletException, IOException {
+    given(request.getHeader("Authorization")).willReturn(null);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    then(filterChain).should().doFilter(request, response);
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+  }
+
+  @DisplayName("필터 실행 - 성공: Bearer 토큰이 유효하면 SecurityContext 에 인증이 설정된다")
+  @Test
+  void doFilter_validToken_setsAuthentication() throws ServletException, IOException {
+    String token = "valid.bearer.token";
+    given(request.getHeader("Authorization")).willReturn("Bearer " + token);
+    willDoNothing().given(tokenProvider).validate(token);
+
+    Authentication mockAuth = createMockAuthentication();
+    given(tokenProvider.getAuthentication(token)).willReturn(mockAuth);
+    given(tokenProvider.parseJti(token)).willReturn("test-jti");
+    given(tokenProvider.parseIssueTime(token)).willReturn(Instant.now());
+    given(blacklistRegistry.isBlacklisted(any(), any(), any())).willReturn(false);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    then(filterChain).should().doFilter(request, response);
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isEqualTo(mockAuth);
+  }
+
+  @DisplayName("필터 실행 - 실패: 유효하지 않은 토큰일 경우 JwtException 이 발생한다")
+  @Test
+  void doFilter_invalidToken_throwsException() throws ServletException, IOException {
+    String token = "invalid.token";
+    given(request.getHeader("Authorization")).willReturn("Bearer " + token);
+    willThrow(new JwtException(JwtErrorCode.VERIFICATION_FAILED)).given(tokenProvider).validate(token);
+
+    assertThatThrownBy(() -> filter.doFilterInternal(request, response, filterChain))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.VERIFICATION_FAILED.getCode());
+    then(filterChain).should(never()).doFilter(any(), any());
+  }
+
+  @DisplayName("필터 실행 - 실패: 블랙리스트에 등록된 토큰일 경우 JwtException 이 발생한다")
+  @Test
+  void doFilter_blacklistedToken_throwsException() throws ServletException, IOException {
+    String token = "blacklisted.token";
+    given(request.getHeader("Authorization")).willReturn("Bearer " + token);
+    willDoNothing().given(tokenProvider).validate(token);
+
+    Authentication mockAuth = createMockAuthentication();
+    given(tokenProvider.getAuthentication(token)).willReturn(mockAuth);
+    given(tokenProvider.parseJti(token)).willReturn("blacklisted-jti");
+    given(tokenProvider.parseIssueTime(token)).willReturn(Instant.now());
+    given(blacklistRegistry.isBlacklisted(any(), any(), any())).willReturn(true);
+
+    assertThatThrownBy(() -> filter.doFilterInternal(request, response, filterChain))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.BLACKLISTED_TOKEN.getCode());
+    then(filterChain).should(never()).doFilter(any(), any());
+  }
+
+  @DisplayName("필터 실행 - 성공: Bearer 가 아닌 Authorization 헤더는 토큰 없이 처리된다")
+  @Test
+  void doFilter_nonBearerHeader_passesThrough() throws ServletException, IOException {
+    given(request.getHeader("Authorization")).willReturn("Basic dXNlcjpwYXNz");
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    then(filterChain).should().doFilter(request, response);
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+  }
+
+  private Authentication createMockAuthentication() {
+    UUID userId = UUID.randomUUID();
+    return new Authentication() {
+      @Override
+      public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public Object getCredentials() {
+        return "token";
+      }
+
+      @Override
+      public Object getDetails() {
+        return null;
+      }
+
+      @Override
+      public Object getPrincipal() {
+        return userId.toString();
+      }
+
+      @Override
+      public boolean isAuthenticated() {
+        return true;
+      }
+
+      @Override
+      public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {}
+
+      @Override
+      public String getName() {
+        return userId.toString();
+      }
+    };
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/filter/JwtAuthenticationFilterTest.java
@@ -142,40 +142,7 @@ class JwtAuthenticationFilterTest {
   }
 
   private Authentication createMockAuthentication() {
-    UUID userId = UUID.randomUUID();
-    return new Authentication() {
-      @Override
-      public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.emptyList();
-      }
-
-      @Override
-      public Object getCredentials() {
-        return "token";
-      }
-
-      @Override
-      public Object getDetails() {
-        return null;
-      }
-
-      @Override
-      public Object getPrincipal() {
-        return userId.toString();
-      }
-
-      @Override
-      public boolean isAuthenticated() {
-        return true;
-      }
-
-      @Override
-      public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {}
-
-      @Override
-      public String getName() {
-        return userId.toString();
-      }
-    };
+    return new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+        UUID.randomUUID().toString(), "token", Collections.emptyList());
   }
 }

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/AuthenticationBuilderTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/AuthenticationBuilderTest.java
@@ -1,0 +1,101 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.Date;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
+
+class AuthenticationBuilderTest {
+
+  @DisplayName("Authentication 생성 - 성공: 단일 역할로 Spring Security Authentication 객체가 생성된다")
+  @Test
+  void buildAuthentication_success() {
+    // given
+    ParsedToken parsedToken = new ParsedToken(
+        "jti-1",
+        "user-uuid-123",
+        new Date(),
+        new Date(System.currentTimeMillis() + 3600000),
+        "USER",
+        null);
+    String tokenString = "test.token.string";
+
+    // when
+    Authentication authentication = AuthenticationBuilder.buildAuthentication(parsedToken, tokenString);
+
+    // then
+    assertThat(authentication).isNotNull();
+    assertThat(authentication.getName()).isEqualTo("user-uuid-123");
+    assertThat(authentication.getCredentials()).isEqualTo(tokenString);
+    assertThat(authentication.getAuthorities()).hasSize(1);
+    assertThat(authentication.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_USER");
+  }
+
+  @DisplayName("Authentication 생성 - 성공: 여러 역할이 콤마로 구분되어 있으면 모두 권한으로 변환된다")
+  @Test
+  void buildAuthentication_multipleRoles_success() {
+    // given
+    ParsedToken parsedToken = new ParsedToken(
+        "jti-2",
+        "admin-uuid-456",
+        new Date(),
+        new Date(System.currentTimeMillis() + 3600000),
+        "USER,ADMIN",
+        null);
+    String tokenString = "test.token.string";
+
+    // when
+    Authentication authentication = AuthenticationBuilder.buildAuthentication(parsedToken, tokenString);
+
+    // then
+    assertThat(authentication).isNotNull();
+    assertThat(authentication.getAuthorities()).hasSize(2);
+    assertThat(authentication.getAuthorities())
+        .extracting(GrantedAuthority::getAuthority)
+        .containsExactlyInAnyOrder("ROLE_USER", "ROLE_ADMIN");
+  }
+
+  @DisplayName("Authentication 생성 - 실패: 역할이 null 이면 JwtException 이 발생한다")
+  @Test
+  void buildAuthentication_nullRole_failure() {
+    // given
+    ParsedToken parsedToken = new ParsedToken(
+        "jti-3",
+        "user-uuid-789",
+        new Date(),
+        new Date(System.currentTimeMillis() + 3600000),
+        null,
+        null);
+    String tokenString = "test.token.string";
+
+    // when & then
+    assertThatThrownBy(() -> AuthenticationBuilder.buildAuthentication(parsedToken, tokenString))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_PARSE_FAILED.getCode());
+  }
+
+  @DisplayName("Authentication 생성 - 실패: 역할이 빈 문자열이면 JwtException 이 발생한다")
+  @Test
+  void buildAuthentication_emptyRole_failure() {
+    // given
+    ParsedToken parsedToken = new ParsedToken(
+        "jti-4",
+        "user-uuid-000",
+        new Date(),
+        new Date(System.currentTimeMillis() + 3600000),
+        "",
+        null);
+    String tokenString = "test.token.string";
+
+    // when & then
+    assertThatThrownBy(() -> AuthenticationBuilder.buildAuthentication(parsedToken, tokenString))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_PARSE_FAILED.getCode());
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/SignedTokenFactoryTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/SignedTokenFactoryTest.java
@@ -1,0 +1,126 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.BDDMockito.given;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jose.crypto.MACVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+
+class SignedTokenFactoryTest {
+
+  private SignedTokenFactory signedTokenFactory;
+  private final String secretKey = "testSecretKeyForJwtSigningMustBeLongEnoughForHS256";
+  private JWSHeader header;
+  private JWSSigner signer;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    header = new JWSHeader(JWSAlgorithm.HS256);
+    signer = new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8));
+    signedTokenFactory = new SignedTokenFactory(header, signer);
+  }
+
+  @DisplayName("JWT 서명 - 성공: 유효한 클레임으로 서명된 토큰이 생성된다")
+  @Test
+  void sign_success() throws Exception {
+    // given
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .subject("testUser")
+        .issueTime(new Date())
+        .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+        .jwtID("test-jti")
+        .build();
+
+    // when
+    String token = signedTokenFactory.sign(claimsSet);
+
+    // then
+    assertThat(token).isNotBlank();
+    String[] parts = token.split("\\.");
+    assertThat(parts).hasSize(3);
+  }
+
+  @DisplayName("JWT 서명 - 실패: 서명 과정에서 예외가 발생하면 JwtException 이 발생한다")
+  @Test
+  void sign_failure_invalidSigner() throws Exception {
+    // given
+    JWSHeader invalidHeader = new JWSHeader(JWSAlgorithm.HS256);
+    JWSSigner failingSigner = mock(JWSSigner.class);
+    given(failingSigner.sign(any(), any()))
+        .willThrow(new JOSEException("Signing failed"));
+    SignedTokenFactory invalidSignedTokenFactory = new SignedTokenFactory(invalidHeader, failingSigner);
+
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .subject("testUser")
+        .issueTime(new Date())
+        .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> invalidSignedTokenFactory.sign(claimsSet))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.SIGN_FAILED.getCode());
+  }
+
+  @DisplayName("JWT 검증 - 성공: 유효한 서명이면 true 를 반환한다")
+  @Test
+  void verify_success() throws Exception {
+    // given
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .subject("testUser")
+        .issueTime(new Date())
+        .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+        .build();
+
+    String serializedToken = signedTokenFactory.sign(claimsSet);
+    SignedJWT signedJWT = SignedJWT.parse(serializedToken);
+    JWSVerifier verifier = new MACVerifier(secretKey.getBytes(StandardCharsets.UTF_8));
+
+    // when
+    boolean isVerified = signedTokenFactory.verify(signedJWT, verifier);
+
+    // then
+    assertThat(isVerified).isTrue();
+  }
+
+  @DisplayName("JWT 검증 - 실패: 잘못된 키로 서명된 토큰은 검증이 실패한다")
+  @Test
+  void verify_failure_wrongKey() throws Exception {
+    // given
+    String wrongSecretKey = "wrongSecretKeyForJwtSigningMustBeLongEnoughForHS256";
+    JWSSigner wrongSigner = new MACSigner(wrongSecretKey.getBytes(StandardCharsets.UTF_8));
+    SignedTokenFactory wrongSignedTokenFactory = new SignedTokenFactory(header, wrongSigner);
+
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .subject("testUser")
+        .issueTime(new Date())
+        .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+        .build();
+
+    String serializedToken = wrongSignedTokenFactory.sign(claimsSet);
+    SignedJWT signedJWT = SignedJWT.parse(serializedToken);
+    JWSVerifier verifier = new MACVerifier(secretKey.getBytes(StandardCharsets.UTF_8));
+
+    // when
+    boolean isVerified = signedTokenFactory.verify(signedJWT, verifier);
+
+    // then
+    assertThat(isVerified).isFalse();
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenBuilderFactoryTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenBuilderFactoryTest.java
@@ -1,0 +1,113 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.nimbusds.jwt.JWTClaimsSet;
+import io.github.metdaisy.amaazon.global.security.jwt.config.JwtProperties;
+
+@ExtendWith(MockitoExtension.class)
+class TokenBuilderFactoryTest {
+
+  @Mock
+  private JwtProperties jwtProperties;
+
+  @InjectMocks
+  private TokenBuilderFactory tokenBuilderFactory;
+
+  @DisplayName("Access Token 클레임 빌드 - 성공: JWT ID, Subject, IssueTime, ExpirationTime, Role 이 설정된다")
+  @Test
+  void buildAccessTokenClaims_success() throws Exception {
+    // given
+    String subject = "user123";
+    String authorities = "ROLE_USER,ROLE_ADMIN";
+    long accessTokenExpiration = 3600L;
+    given(jwtProperties.accessTokenExpiration()).willReturn(accessTokenExpiration);
+
+    // when
+    JWTClaimsSet claimsSet = tokenBuilderFactory.buildAccessTokenClaims(subject, authorities);
+
+    // then
+    assertThat(claimsSet).isNotNull();
+    assertThat(claimsSet.getJWTID()).isNotBlank();
+    assertThat(claimsSet.getSubject()).isEqualTo(subject);
+    assertThat(claimsSet.getIssueTime()).isNotNull();
+    assertThat(claimsSet.getExpirationTime()).isNotNull();
+    assertThat(claimsSet.getExpirationTime()).isAfter(claimsSet.getIssueTime());
+
+    long expectedExpirationMs = accessTokenExpiration * 1000;
+    long actualExpirationDiff = claimsSet.getExpirationTime().getTime() - claimsSet.getIssueTime().getTime();
+    assertThat(actualExpirationDiff).isEqualTo(expectedExpirationMs);
+
+    assertThat(claimsSet.getStringClaim("role")).isEqualTo(authorities);
+  }
+
+  @DisplayName("Access Token 클레임 빌드 - 성공: authorities 가 빈 문자열일 경우 Role 클레임이 설정되지 않는다")
+  @Test
+  void buildAccessTokenClaims_noAuthorities() throws Exception {
+    // given
+    String subject = "guest";
+    String authorities = "";
+    given(jwtProperties.accessTokenExpiration()).willReturn(3600L);
+
+    // when
+    JWTClaimsSet claimsSet = tokenBuilderFactory.buildAccessTokenClaims(subject, authorities);
+
+    // then
+    assertThat(claimsSet.getStringClaim("role")).isNull();
+  }
+
+  @DisplayName("Refresh Token 클레임 빌드 - 성공: JWT ID, Subject, IssueTime, ExpirationTime 가 설정된다")
+  @Test
+  void buildRefreshTokenClaims_success() {
+    // given
+    String subject = "user456";
+    long refreshTokenExpiration = 7200L;
+    given(jwtProperties.refreshTokenExpiration()).willReturn(refreshTokenExpiration);
+
+    // when
+    JWTClaimsSet claimsSet = tokenBuilderFactory.buildRefreshTokenClaims(subject);
+
+    // then
+    assertThat(claimsSet).isNotNull();
+    assertThat(claimsSet.getJWTID()).isNotBlank();
+    assertThat(claimsSet.getSubject()).isEqualTo(subject);
+    assertThat(claimsSet.getIssueTime()).isNotNull();
+    assertThat(claimsSet.getExpirationTime()).isNotNull();
+    assertThat(claimsSet.getExpirationTime()).isAfter(claimsSet.getIssueTime());
+
+    long expectedExpirationMs = refreshTokenExpiration * 1000;
+    long actualExpirationDiff = claimsSet.getExpirationTime().getTime() - claimsSet.getIssueTime().getTime();
+    assertThat(actualExpirationDiff).isEqualTo(expectedExpirationMs);
+  }
+
+  @DisplayName("Guest Token 클레임 빌드 - 성공: Provider, ProviderId, IssueTime, ExpirationTime 가 설정된다")
+  @Test
+  void buildGuestTokenClaims_success() throws Exception {
+    // given
+    String provider = "google";
+    String providerId = "google_12345";
+    long guestTokenExpiration = 1800L;
+    given(jwtProperties.guestTokenExpiration()).willReturn(guestTokenExpiration);
+
+    // when
+    JWTClaimsSet claimsSet = tokenBuilderFactory.buildGuestTokenClaims(provider, providerId);
+
+    // then
+    assertThat(claimsSet).isNotNull();
+    assertThat(claimsSet.getJWTID()).isNotBlank();
+    assertThat(claimsSet.getStringClaim("provider")).isEqualTo(provider);
+    assertThat(claimsSet.getStringClaim("providerId")).isEqualTo(providerId);
+    assertThat(claimsSet.getIssueTime()).isNotNull();
+    assertThat(claimsSet.getExpirationTime()).isNotNull();
+    assertThat(claimsSet.getExpirationTime()).isAfter(claimsSet.getIssueTime());
+
+    long actualExpirationDiff = claimsSet.getExpirationTime().getTime() - claimsSet.getIssueTime().getTime();
+    assertThat(actualExpirationDiff).isEqualTo(guestTokenExpiration);
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParserTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenParserTest.java
@@ -1,0 +1,180 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
+
+class TokenParserTest {
+
+  private final String secretKey = "testSecretKeyForJwtSigningMustBeLongEnoughForHS256";
+  private JWSHeader header;
+  private JWSSigner signer;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    header = new JWSHeader(JWSAlgorithm.HS256);
+    signer = new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @DisplayName("JWT 파싱 - 성공: 유효한 토큰으로부터 모든 클레임을 파싱한다")
+  @Test
+  void parse_success() throws Exception {
+    // given
+    String subject = "testUser";
+    String role = "ROLE_USER";
+    String jti = UUID.randomUUID().toString();
+    long currentTimeSec = System.currentTimeMillis() / 1000 * 1000;
+    Date now = new Date(currentTimeSec);
+    Date expiration = new Date(currentTimeSec + 3600000);
+
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .jwtID(jti)
+        .subject(subject)
+        .issueTime(now)
+        .expirationTime(expiration)
+        .claim("role", role)
+        .claim("provider", "google")
+        .build();
+
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(signer);
+    String token = signedJWT.serialize();
+
+    // when
+    ParsedToken parsedToken = TokenParser.parse(token);
+
+    // then
+    assertThat(parsedToken).isNotNull();
+    assertThat(parsedToken.jti()).isEqualTo(jti);
+    assertThat(parsedToken.subject()).isEqualTo(subject);
+    assertThat(parsedToken.role()).isEqualTo(role);
+    assertThat(parsedToken.issueTime()).isEqualTo(now);
+    assertThat(parsedToken.expirationTime()).isEqualTo(expiration);
+    assertThat(parsedToken.otherClaims().get("provider")).isEqualTo("google");
+  }
+
+  @DisplayName("JTI 파싱 - 성공: 토큰에서 JTI 를 추출한다")
+  @Test
+  void parseJti_success() throws Exception {
+    // given
+    String jti = UUID.randomUUID().toString();
+    ParsedToken parsedToken = createParsedToken(jti, "subject");
+
+    // when
+    String parsedJti = TokenParser.parseJti(parsedToken);
+
+    // then
+    assertThat(parsedJti).isEqualTo(jti);
+  }
+
+  @DisplayName("JTI 파싱 - 실패: JTI 가 null 이면 JwtException 이 발생한다")
+  @Test
+  void parseJti_null_failure() {
+    // given
+    ParsedToken parsedToken = new ParsedToken(null, "subject", new Date(), new Date(), "role", null);
+
+    // when & then
+    assertThatThrownBy(() -> TokenParser.parseJti(parsedToken))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_PARSE_FAILED.getCode());
+  }
+
+  @DisplayName("IssuedAt 파싱 - 성공: 토큰에서 IssuedAt 을 추출한다")
+  @Test
+  void parseIssueTime_success() throws Exception {
+    // given
+    String jti = UUID.randomUUID().toString();
+    long currentTimeSec = System.currentTimeMillis() / 1000 * 1000;
+    Date now = new Date(currentTimeSec);
+    ParsedToken parsedToken = createParsedToken(jti, "subject", now);
+
+    // when
+    Instant issueTime = TokenParser.parseIssueTime(parsedToken);
+
+    // then
+    assertThat(issueTime).isEqualTo(now.toInstant());
+  }
+
+  @DisplayName("IssuedAt 파싱 - 실패: IssueTime 이 null 이면 JwtException 이 발생한다")
+  @Test
+  void parseIssueTime_null_failure() {
+    // given
+    ParsedToken parsedToken = new ParsedToken("jti", "subject", null, new Date(), "role", null);
+
+    // when & then
+    assertThatThrownBy(() -> TokenParser.parseIssueTime(parsedToken))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_PARSE_FAILED.getCode());
+  }
+
+  @DisplayName("클레임 파싱 - 성공: 토큰에서 지정된 키의 클레임을 추출한다")
+  @Test
+  void parseClaim_success() throws Exception {
+    // given
+    String jti = UUID.randomUUID().toString();
+    java.util.Map<String, Object> otherClaims = new java.util.HashMap<>();
+    otherClaims.put("provider", "google");
+    ParsedToken parsedToken = new ParsedToken(jti, "subject", new Date(System.currentTimeMillis() / 1000 * 1000),
+        new Date(System.currentTimeMillis() / 1000 * 1000), "role", otherClaims);
+
+    // when
+    String provider = TokenParser.parseClaim(parsedToken, "provider");
+
+    // then
+    assertThat(provider).isEqualTo("google");
+  }
+
+  @DisplayName("클레임 파싱 - 실패: 존재하지 않는 키로 클레임을 조회하면 JwtException 이 발생한다")
+  @Test
+  void parseClaim_nonExistentKey_failure() {
+    // given
+    ParsedToken parsedToken = new ParsedToken("jti", "subject", new Date(), new Date(), "role", null);
+
+    // when & then
+    assertThatThrownBy(() -> TokenParser.parseClaim(parsedToken, "nonExistent"))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_PARSE_FAILED.getCode());
+  }
+
+  @DisplayName("JWT 파싱 - 실패: 유효하지 않은 토큰 형식일 경우 JwtException 이 발생한다")
+  @Test
+  void parse_invalidToken_failure() {
+    // when & then
+    assertThatThrownBy(() -> TokenParser.parse("invalid.token.format"))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_PARSE_FAILED.getCode());
+  }
+
+  private ParsedToken createParsedToken(String jti, String subject) throws Exception {
+    return createParsedToken(jti, subject, new Date(System.currentTimeMillis() / 1000 * 1000));
+  }
+
+  private ParsedToken createParsedToken(String jti, String subject, Date issueTime) throws Exception {
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .jwtID(jti)
+        .subject(subject)
+        .issueTime(issueTime)
+        .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+        .claim("role", "ROLE_USER")
+        .build();
+
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(signer);
+    return TokenParser.parse(signedJWT.serialize());
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenValidatorTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/builder/TokenValidatorTest.java
@@ -1,0 +1,172 @@
+package io.github.metdaisy.amaazon.global.security.jwt.builder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jose.crypto.MACVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+import io.github.metdaisy.amaazon.global.security.jwt.model.ParsedToken;
+
+@ExtendWith(MockitoExtension.class)
+class TokenValidatorTest {
+
+  @Mock
+  private SignedTokenFactory signedTokenFactory;
+
+  @InjectMocks
+  private TokenValidator tokenValidator;
+
+  private final String secretKey = "testSecretKeyForJwtSigningMustBeLongEnoughForHS256";
+  private JWSHeader header;
+  private JWSVerifier verifier;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    header = new JWSHeader(JWSAlgorithm.HS256);
+    verifier = new MACVerifier(secretKey.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @DisplayName("토큰 검증 - 성공: 유효한 토큰은 서명 및 만료 시간 검증을 통과한다")
+  @Test
+  void validate_success() throws Exception {
+    // given
+    JWTClaimsSet claimsSet = createValidClaimsSet();
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8)));
+    String token = signedJWT.serialize();
+
+    given(signedTokenFactory.verify(any(), any())).willReturn(true);
+
+    // when & then
+    tokenValidator.validate(token, verifier);
+  }
+
+  @DisplayName("토큰 검증 - 실패: 서명 검증 실패 시 JwtException 이 발생한다")
+  @Test
+  void validate_signatureFailure_failure() throws Exception {
+    // given
+    JWTClaimsSet claimsSet = createValidClaimsSet();
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8)));
+    String token = signedJWT.serialize();
+
+    given(signedTokenFactory.verify(any(), any())).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> tokenValidator.validate(token, verifier))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.VERIFICATION_FAILED.getCode());
+  }
+
+  @DisplayName("서명 검증 - 성공: 유효한 서명일 경우 예외가 발생하지 않는다")
+  @Test
+  void validateSignature_success() throws Exception {
+    // given
+    JWTClaimsSet claimsSet = createValidClaimsSet();
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8)));
+    String token = signedJWT.serialize();
+
+    given(signedTokenFactory.verify(any(), any())).willReturn(true);
+
+    // when & then
+    tokenValidator.validateSignature(token, verifier);
+    then(signedTokenFactory).should().verify(any(), any());
+  }
+
+  @DisplayName("서명 검증 - 실패: 유효하지 않은 서명일 경우 JwtException 이 발생한다")
+  @Test
+  void validateSignature_failure() throws Exception {
+    // given
+    JWTClaimsSet claimsSet = createValidClaimsSet();
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8)));
+    String token = signedJWT.serialize();
+
+    given(signedTokenFactory.verify(any(), any())).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> tokenValidator.validateSignature(token, verifier))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.VERIFICATION_FAILED.getCode());
+  }
+
+  @DisplayName("만료 시간 검증 - 성공: 유효한 만료 시간일 경우 예외가 발생하지 않는다")
+  @Test
+  void validateExpiration_success() {
+    // given
+    ParsedToken parsedToken = new ParsedToken(
+        "jti",
+        "subject",
+        new Date(),
+        new Date(System.currentTimeMillis() + 3600000),
+        "role",
+        null);
+
+    // when & then
+    tokenValidator.validateExpiration(parsedToken);
+  }
+
+  @DisplayName("만료 시간 검증 - 실패: 만료된 토큰일 경우 JwtException 이 발생한다")
+  @Test
+  void validateExpiration_expired_failure() {
+    // given
+    ParsedToken parsedToken = new ParsedToken(
+        "jti",
+        "subject",
+        new Date(),
+        new Date(System.currentTimeMillis() - 3600000),
+        "role",
+        null);
+
+    // when & then
+    assertThatThrownBy(() -> tokenValidator.validateExpiration(parsedToken))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_EXPIRED.getCode());
+  }
+
+  @DisplayName("만료 시간 검증 - 실패: 만료 시간이 null 일 경우 JwtException 이 발생한다")
+  @Test
+  void validateExpiration_nullExpiration_failure() {
+    // given
+    ParsedToken parsedToken = new ParsedToken(
+        "jti",
+        "subject",
+        new Date(),
+        null,
+        "role",
+        null);
+
+    // when & then
+    assertThatThrownBy(() -> tokenValidator.validateExpiration(parsedToken))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_PARSE_FAILED.getCode());
+  }
+
+  private JWTClaimsSet createValidClaimsSet() {
+    return new JWTClaimsSet.Builder()
+        .subject("testUser")
+        .issueTime(new Date())
+        .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+        .jwtID("test-jti")
+        .claim("role", "ROLE_USER")
+        .build();
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProviderTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProviderTest.java
@@ -1,0 +1,253 @@
+package io.github.metdaisy.amaazon.global.security.jwt.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.github.metdaisy.amaazon.global.security.jwt.builder.TokenBuilderFactory;
+import io.github.metdaisy.amaazon.global.security.jwt.builder.TokenValidator;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtErrorCode;
+import io.github.metdaisy.amaazon.global.security.jwt.exception.JwtException;
+
+@ExtendWith(MockitoExtension.class)
+class JwtTokenProviderTest {
+
+  @Mock
+  private TokenBuilderFactory tokenBuilderFactory;
+
+  @Mock
+  private io.github.metdaisy.amaazon.global.security.jwt.builder.SignedTokenFactory signedTokenFactory;
+
+  @Mock
+  private TokenValidator tokenValidator;
+
+  @Mock
+  private JWSVerifier verifier;
+
+  @InjectMocks
+  private JwtTokenProvider jwtTokenProvider;
+
+  private final String secretKey = "testSecretKeyForJwtSigningMustBeLongEnoughForHS256";
+  private JWSHeader header;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    header = new JWSHeader(JWSAlgorithm.HS256);
+  }
+
+  @DisplayName("Access Token 생성 - 성공: 클레임 빌드 및 서명이 호출되어 토큰이 생성된다")
+  @Test
+  void generateAccessToken_success() {
+    String subject = "user123";
+    String authorities = "ROLE_USER";
+    JWTClaimsSet mockClaims = new JWTClaimsSet.Builder().subject(subject).build();
+    String mockToken = "mock.access.token";
+
+    given(tokenBuilderFactory.buildAccessTokenClaims(subject, authorities)).willReturn(mockClaims);
+    given(signedTokenFactory.sign(mockClaims)).willReturn(mockToken);
+
+    String token = jwtTokenProvider.generateAccessToken(subject, authorities);
+
+    assertThat(token).isEqualTo(mockToken);
+  }
+
+  @DisplayName("Refresh Token 생성 - 성공: 클레임 빌드 및 서명이 호출되어 토큰이 생성된다")
+  @Test
+  void generateRefreshToken_success() {
+    String subject = "user456";
+    JWTClaimsSet mockClaims = new JWTClaimsSet.Builder().subject(subject).build();
+    String mockToken = "mock.refresh.token";
+
+    given(tokenBuilderFactory.buildRefreshTokenClaims(subject)).willReturn(mockClaims);
+    given(signedTokenFactory.sign(mockClaims)).willReturn(mockToken);
+
+    String token = jwtTokenProvider.generateRefreshToken(subject);
+
+    assertThat(token).isEqualTo(mockToken);
+  }
+
+  @DisplayName("Guest Token 생성 - 성공: 클레임 빌드 및 서명이 호출되어 토큰이 생성된다")
+  @Test
+  void generateGuestToken_success() {
+    String provider = "google";
+    String providerId = "google_12345";
+    JWTClaimsSet mockClaims = new JWTClaimsSet.Builder()
+        .claim("provider", provider)
+        .claim("providerId", providerId)
+        .build();
+    String mockToken = "mock.guest.token";
+
+    given(tokenBuilderFactory.buildGuestTokenClaims(provider, providerId)).willReturn(mockClaims);
+    given(signedTokenFactory.sign(mockClaims)).willReturn(mockToken);
+
+    String token = jwtTokenProvider.generateGuestToken(provider, providerId);
+
+    assertThat(token).isEqualTo(mockToken);
+  }
+
+  @DisplayName("Authentication 조회 - 성공: 유효한 토큰으로 Authentication 이 생성된다")
+  @Test
+  void getAuthentication_success() throws Exception {
+    String subject = "user-uuid-123";
+    String role = "USER";
+    String jti = UUID.randomUUID().toString();
+    Date now = new Date();
+    Date expiration = new Date(System.currentTimeMillis() + 3600000);
+
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .jwtID(jti)
+        .subject(subject)
+        .issueTime(now)
+        .expirationTime(expiration)
+        .claim("role", role)
+        .build();
+
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8)));
+    String token = signedJWT.serialize();
+
+    Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+    assertThat(authentication).isNotNull();
+    assertThat(authentication.getName()).isEqualTo(subject);
+    assertThat(authentication.getAuthorities()).hasSize(1);
+  }
+
+  @DisplayName("Authentication 조회 - 실패: 만료된 토큰일 경우 JwtException 이 발생한다")
+  @Test
+  void getAuthentication_expiredToken_failure() throws Exception {
+    String subject = "user-uuid-123";
+    String role = "USER";
+    String jti = UUID.randomUUID().toString();
+    Date now = new Date();
+    Date expiration = new Date(System.currentTimeMillis() - 3600000);
+
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .jwtID(jti)
+        .subject(subject)
+        .issueTime(now)
+        .expirationTime(expiration)
+        .claim("role", role)
+        .build();
+
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8)));
+    String token = signedJWT.serialize();
+
+    willThrow(new JwtException(JwtErrorCode.TOKEN_EXPIRED))
+        .given(tokenValidator).validateExpiration(org.mockito.ArgumentMatchers.any());
+
+    assertThatThrownBy(() -> jwtTokenProvider.getAuthentication(token))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_EXPIRED.getCode());
+  }
+
+  @DisplayName("토큰 검증 - 실패: 유효하지 않은 토큰일 경우 JwtException 이 발생한다")
+  @Test
+  void validate_invalidSignature_failure() throws Exception {
+    String invalidToken = "invalid.token.format";
+
+    willThrow(new JwtException(JwtErrorCode.VERIFICATION_FAILED)).given(tokenValidator).validate(invalidToken,
+        verifier);
+
+    assertThatThrownBy(() -> jwtTokenProvider.validate(invalidToken))
+        .isInstanceOf(JwtException.class)
+        .hasFieldOrPropertyWithValue("code", JwtErrorCode.VERIFICATION_FAILED.getCode());
+  }
+
+  @DisplayName("JTI 파싱 - 성공: 유효한 토큰에서 JTI 가 추출된다")
+  @Test
+  void parseJti_success() throws Exception {
+    String jti = UUID.randomUUID().toString();
+    String subject = "user-uuid-123";
+    Date now = new Date();
+    Date expiration = new Date(System.currentTimeMillis() + 3600000);
+
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .jwtID(jti)
+        .subject(subject)
+        .issueTime(now)
+        .expirationTime(expiration)
+        .claim("role", "USER")
+        .build();
+
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8)));
+    String token = signedJWT.serialize();
+
+    String parsedJti = jwtTokenProvider.parseJti(token);
+
+    assertThat(parsedJti).isEqualTo(jti);
+  }
+
+  @DisplayName("IssuedAt 파싱 - 성공: 유효한 토큰에서 발행 시간이 추출된다")
+  @Test
+  void parseIssueTime_success() throws Exception {
+    String jti = UUID.randomUUID().toString();
+    String subject = "user-uuid-123";
+    long currentTimeSec = System.currentTimeMillis() / 1000 * 1000;
+    Date now = new Date(currentTimeSec);
+    Date expiration = new Date(currentTimeSec + 3600000);
+
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .jwtID(jti)
+        .subject(subject)
+        .issueTime(now)
+        .expirationTime(expiration)
+        .claim("role", "USER")
+        .build();
+
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8)));
+    String token = signedJWT.serialize();
+
+    Instant issueTime = jwtTokenProvider.parseIssueTime(token);
+
+    assertThat(issueTime).isEqualTo(now.toInstant());
+  }
+
+  @DisplayName("Provider 파싱 - 성공: Guest 토큰에서 provider 클레임이 추출된다")
+  @Test
+  void parseProvider_success() throws Exception {
+    String provider = "google";
+    String providerId = "google_12345";
+    String jti = UUID.randomUUID().toString();
+    Date now = new Date();
+    Date expiration = new Date(System.currentTimeMillis() + 3600000);
+
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+        .jwtID(jti)
+        .subject("guest")
+        .issueTime(now)
+        .expirationTime(expiration)
+        .claim("provider", provider)
+        .claim("providerId", providerId)
+        .build();
+
+    SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+    signedJWT.sign(new MACSigner(secretKey.getBytes(StandardCharsets.UTF_8)));
+    String token = signedJWT.serialize();
+
+    String parsedProvider = jwtTokenProvider.parseProvider(token, "provider");
+
+    assertThat(parsedProvider).isEqualTo(provider);
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProviderTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProviderTest.java
@@ -2,8 +2,11 @@ package io.github.metdaisy.amaazon.global.security.jwt.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+
+import io.github.metdaisy.amaazon.global.security.jwt.builder.SignedTokenFactory;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
@@ -34,7 +37,7 @@ class JwtTokenProviderTest {
   private TokenBuilderFactory tokenBuilderFactory;
 
   @Mock
-  private io.github.metdaisy.amaazon.global.security.jwt.builder.SignedTokenFactory signedTokenFactory;
+  private SignedTokenFactory signedTokenFactory;
 
   @Mock
   private TokenValidator tokenValidator;
@@ -153,7 +156,7 @@ class JwtTokenProviderTest {
     String token = signedJWT.serialize();
 
     willThrow(new JwtException(JwtErrorCode.TOKEN_EXPIRED))
-        .given(tokenValidator).validateExpiration(org.mockito.ArgumentMatchers.any());
+        .given(tokenValidator).validateExpiration(any());
 
     assertThatThrownBy(() -> jwtTokenProvider.getAuthentication(token))
         .isInstanceOf(JwtException.class)

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProviderTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/provider/JwtTokenProviderTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
 
 import io.github.metdaisy.amaazon.global.security.jwt.builder.SignedTokenFactory;
 import java.nio.charset.StandardCharsets;
@@ -161,6 +163,18 @@ class JwtTokenProviderTest {
     assertThatThrownBy(() -> jwtTokenProvider.getAuthentication(token))
         .isInstanceOf(JwtException.class)
         .hasFieldOrPropertyWithValue("code", JwtErrorCode.TOKEN_EXPIRED.getCode());
+  }
+
+  @DisplayName("토큰 검증 - 성공: 유효한 토큰일 경우 예외가 발생하지 않는다")
+  @Test
+  void validate_success() {
+    String validToken = "valid.token.format";
+
+    willDoNothing().given(tokenValidator).validate(validToken, verifier);
+
+    jwtTokenProvider.validate(validToken);
+
+    verify(tokenValidator).validate(validToken, verifier);
   }
 
   @DisplayName("토큰 검증 - 실패: 유효하지 않은 토큰일 경우 JwtException 이 발생한다")

--- a/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/registry/CaffeineBlacklistRegistryTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/global/security/jwt/registry/CaffeineBlacklistRegistryTest.java
@@ -1,0 +1,164 @@
+package io.github.metdaisy.amaazon.global.security.jwt.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.github.benmanes.caffeine.cache.Cache;
+import io.github.metdaisy.amaazon.global.security.jwt.event.BlacklistTokenCreatedEvent;
+import io.github.metdaisy.amaazon.global.security.jwt.event.BlacklistUserCreatedEvent;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class CaffeineBlacklistRegistryTest {
+
+  @Mock
+  private Cache<String, Instant> tokenBlacklist;
+
+  @Mock
+  private Cache<UUID, Instant> userBlacklist;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+
+  @Captor
+  private ArgumentCaptor<BlacklistTokenCreatedEvent> tokenEventCaptor;
+
+  @Captor
+  private ArgumentCaptor<BlacklistUserCreatedEvent> userEventCaptor;
+
+  private CaffeineBlacklistRegistry blacklistRegistry;
+
+  @BeforeEach
+  void setUp() {
+    blacklistRegistry = new CaffeineBlacklistRegistry(tokenBlacklist, userBlacklist, eventPublisher);
+  }
+
+  @DisplayName("토큰 블랙리스트 등록 - 성공: 토큰 JTI 가 캐시에 저장되고 이벤트가 발행된다")
+  @Test
+  void blacklistToken_success() {
+    // given
+    String jti = "test-jti-123";
+    Instant expiredAt = Instant.now().plusSeconds(3600);
+
+    // when
+    blacklistRegistry.blacklistToken(jti, expiredAt);
+
+    // then
+    then(tokenBlacklist).should().put(jti, expiredAt);
+    then(eventPublisher).should().publishEvent(tokenEventCaptor.capture());
+    BlacklistTokenCreatedEvent capturedEvent = tokenEventCaptor.getValue();
+    assertThat(capturedEvent.jti()).isEqualTo(jti);
+    assertThat(capturedEvent.expiredAt()).isEqualTo(expiredAt);
+  }
+
+  @DisplayName("사용자 블랙리스트 등록 - 성공: 사용자 ID 가 캐시에 저장되고 이벤트가 발행된다")
+  @Test
+  void blacklistUser_success() {
+    // given
+    UUID userId = UUID.randomUUID();
+    Instant compromisedAt = Instant.now();
+
+    // when
+    blacklistRegistry.blacklistUser(userId, compromisedAt);
+
+    // then
+    then(userBlacklist).should().put(userId, compromisedAt);
+    then(eventPublisher).should().publishEvent(userEventCaptor.capture());
+    BlacklistUserCreatedEvent capturedEvent = userEventCaptor.getValue();
+    assertThat(capturedEvent.userId()).isEqualTo(userId);
+    assertThat(capturedEvent.compromisedAt()).isEqualTo(compromisedAt);
+  }
+
+  @DisplayName("블랙리스트 확인 - 성공: 토큰 JTI 가 블랙리스트에 있으면 true 를 반환한다")
+  @Test
+  void isBlacklisted_tokenBlacklisted_returnsTrue() {
+    // given
+    String jti = "blacklisted-jti";
+    Instant expiredAt = Instant.now().plusSeconds(3600);
+    given(tokenBlacklist.getIfPresent(jti)).willReturn(expiredAt);
+
+    UUID userId = UUID.randomUUID();
+    Instant issuedAt = Instant.now();
+
+    // when
+    boolean result = blacklistRegistry.isBlacklisted(jti, userId, issuedAt);
+
+    // then
+    assertThat(result).isTrue();
+    then(userBlacklist).should(never()).getIfPresent(any());
+  }
+
+  @DisplayName("블랙리스트 확인 - 성공: 사용자 ID 가 블랙리스트에 있고 토큰 발급 시간이 사용자 블랙리스트 등록 시간 이전이면 true 를 반환한다")
+  @Test
+  void isBlacklisted_userBlacklisted_issuedBefore_returnsTrue() {
+    // given
+    String jti = "valid-jti";
+    given(tokenBlacklist.getIfPresent(jti)).willReturn(null);
+
+    UUID userId = UUID.randomUUID();
+    Instant compromisedAt = Instant.now().minusSeconds(3600);
+    given(userBlacklist.getIfPresent(userId)).willReturn(compromisedAt);
+
+    Instant issuedAt = Instant.now().minusSeconds(7200);
+
+    // when
+    boolean result = blacklistRegistry.isBlacklisted(jti, userId, issuedAt);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @DisplayName("블랙리스트 확인 - 실패: 토큰 JTI 와 사용자 ID 가 모두 블랙리스트에 없으면 false 를 반환한다")
+  @Test
+  void isBlacklisted_notBlacklisted_returnsFalse() {
+    // given
+    String jti = "valid-jti";
+    given(tokenBlacklist.getIfPresent(jti)).willReturn(null);
+
+    UUID userId = UUID.randomUUID();
+    given(userBlacklist.getIfPresent(userId)).willReturn(null);
+
+    Instant issuedAt = Instant.now();
+
+    // when
+    boolean result = blacklistRegistry.isBlacklisted(jti, userId, issuedAt);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @DisplayName("블랙리스트 확인 - 실패: 사용자 ID 가 블랙리스트에 있지만 토큰 발급 시간이 등록 시간 이후이면 false 를 반환한다")
+  @Test
+  void isBlacklisted_userBlacklisted_issuedAfter_returnsFalse() {
+    // given
+    String jti = "valid-jti";
+    given(tokenBlacklist.getIfPresent(jti)).willReturn(null);
+
+    UUID userId = UUID.randomUUID();
+    Instant compromisedAt = Instant.now().minusSeconds(3600);
+    given(userBlacklist.getIfPresent(userId)).willReturn(compromisedAt);
+
+    Instant issuedAt = Instant.now();
+
+    // when
+    boolean result = blacklistRegistry.isBlacklisted(jti, userId, issuedAt);
+
+    // then
+    assertThat(result).isFalse();
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/user/application/port/in/UserQueryApiTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/user/application/port/in/UserQueryApiTest.java
@@ -1,7 +1,6 @@
 package io.github.metdaisy.amaazon.user.application.port.in;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import java.util.Optional;
@@ -41,8 +40,8 @@ class UserQueryApiTest {
 
     Optional<UserDto> result = userQueryApi.findById(userId);
 
-    assertTrue(result.isPresent());
-    assertEquals(userId, result.get().id());
+    assertThat(result).isPresent();
+    assertThat(result.get().id()).isEqualTo(userId);
   }
 
   @Test
@@ -52,6 +51,6 @@ class UserQueryApiTest {
     given(repository.existsById(userId)).willReturn(true);
 
     boolean exists = userQueryApi.existsByUserId(userId);
-    assertTrue(exists);
+    assertThat(exists).isTrue();
   }
 }

--- a/src/test/java/io/github/metdaisy/amaazon/user/application/port/in/UserQueryApiTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/user/application/port/in/UserQueryApiTest.java
@@ -1,0 +1,57 @@
+package io.github.metdaisy.amaazon.user.application.port.in;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import io.github.metdaisy.amaazon.user.application.dto.UserDto;
+import io.github.metdaisy.amaazon.user.application.mapper.UserApiMapper;
+import io.github.metdaisy.amaazon.user.domain.entity.User;
+import io.github.metdaisy.amaazon.user.domain.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserQueryApiTest {
+
+  @Mock
+  private UserRepository repository;
+
+  @Mock
+  private UserApiMapper mapper;
+
+  @InjectMocks
+  private UserQueryApi userQueryApi;
+
+  @Test
+  @DisplayName("findById")
+  void findById() {
+    UUID userId = UUID.randomUUID();
+    User user = User.createUser("tester", "01012345678");
+    UserDto userDto = new UserDto(userId, "USER");
+    
+    given(repository.findById(userId)).willReturn(Optional.of(user));
+    given(mapper.toDto(user)).willReturn(userDto);
+
+    Optional<UserDto> result = userQueryApi.findById(userId);
+
+    assertTrue(result.isPresent());
+    assertEquals(userId, result.get().id());
+  }
+
+  @Test
+  @DisplayName("existsByUserId")
+  void existsByUserId() {
+    UUID userId = UUID.randomUUID();
+    given(repository.existsById(userId)).willReturn(true);
+
+    boolean exists = userQueryApi.existsByUserId(userId);
+    assertTrue(exists);
+  }
+}

--- a/src/test/java/io/github/metdaisy/amaazon/user/application/service/UserServiceTest.java
+++ b/src/test/java/io/github/metdaisy/amaazon/user/application/service/UserServiceTest.java
@@ -1,0 +1,96 @@
+package io.github.metdaisy.amaazon.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import io.github.metdaisy.amaazon.user.application.dto.UserCreateRequest;
+import io.github.metdaisy.amaazon.user.domain.entity.User;
+import io.github.metdaisy.amaazon.user.domain.event.UserCreatedEvent;
+import io.github.metdaisy.amaazon.user.domain.exception.UserErrorCode;
+import io.github.metdaisy.amaazon.user.domain.exception.UserException;
+import io.github.metdaisy.amaazon.user.domain.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private UserService userService;
+
+    @DisplayName("사용자 생성 - 성공: 유효한 이름과 전화번호로 신규 사용자를 생성한다_성공")
+    @Test
+    void create_user_success() {
+        // given
+        String name = "김철수";
+        String phoneNumber = "01012345678";
+
+        User mockUser = User.createUser(name, phoneNumber);
+        given(userRepository.existsByName(name)).willReturn(false);
+        given(userRepository.existsByPhoneNumber(phoneNumber)).willReturn(false);
+        given(userRepository.save(any(User.class))).willReturn(mockUser);
+
+        // when
+        UserCreateRequest request = new UserCreateRequest(name, phoneNumber, "test@test.com", "password");
+        User user = userService.create(request);
+
+        // then
+        assertThat(user).isEqualTo(mockUser);
+        assertThat(user.getName()).isEqualTo(name);
+        assertThat(user.getPhoneNumber()).isEqualTo(phoneNumber);
+        verify(eventPublisher, times(1)).publishEvent(any(UserCreatedEvent.class));
+    }
+
+    @DisplayName("사용자 생성 - 실패: 중복된 이름으로 인해 사용자 생성이 거부된다_실패")
+    @Test
+    void create_user_duplicate_name_fail() {
+        // given
+        String name = "김철수";
+        String phoneNumber = "01012345678";
+
+        given(userRepository.existsByName(name)).willReturn(true);
+
+        // when & then
+        UserCreateRequest request = new UserCreateRequest(name, phoneNumber, "test@test.com", "password");
+        assertThatThrownBy(() -> userService.create(request))
+                .isInstanceOf(UserException.class)
+                .hasFieldOrPropertyWithValue("code", UserErrorCode.NAME_ALREADY_EXISTS.getCode());
+        verify(userRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @DisplayName("사용자 생성 - 실패: 중복된 전화번호로 인해 사용자 생성이 거부된다_실패")
+    @Test
+    void create_user_duplicate_phone_number_fail() {
+        // given
+        String name = "김철수";
+        String phoneNumber = "01012345678";
+
+        given(userRepository.existsByName(name)).willReturn(false);
+        given(userRepository.existsByPhoneNumber(phoneNumber)).willReturn(true);
+
+        // when & then
+        UserCreateRequest request = new UserCreateRequest(name, phoneNumber, "test@test.com", "password");
+        assertThatThrownBy(() -> userService.create(request))
+                .isInstanceOf(UserException.class)
+                .hasFieldOrPropertyWithValue("code", UserErrorCode.PHONE_ALREADY_EXISTS.getCode());
+        verify(userRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+}
+

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,30 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        jdbc.batch_size: 100
+        order_inserts: true
+        order_updates: true
+        default_batch_fetch_size: 500
+    open-in-view: false
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:db/migration/V1__init_schema.sql
+
+amaazon:
+  jwt:
+    registry-store-type: caffeine
+    access-token-expiration: 3600000
+    refresh-token-expiration: 86400000
+    guest-token-expiration: 600000
+    secret-key: test-secret-key-test-secret-key-test-secret-key-test-secret-key
+
+logging:
+  level:
+    root: INFO
+    io.github.metdaisy.amaazon: info

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -23,6 +23,11 @@ amaazon:
     refresh-token-expiration: 86400000
     guest-token-expiration: 600000
     secret-key: test-secret-key-test-secret-key-test-secret-key-test-secret-key
+    cookie:
+      name: REFRESH_TOKEN
+      path: /
+      same-site: LAX
+      secure: false
 
 logging:
   level:


### PR DESCRIPTION
close: #92 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 🔗 Related Issue
- close `#92`

## 📝 Work Details
JWT 처리와 전역 예외 처리 로직이 단일 클래스에 집중되어 있어 예외별 응답·로깅 정책을 확장하고 테스트하기 어려웠습니다. 또한 JWT 파싱 실패 시 토큰이나 사용자 입력이 로그에 노출될 가능성이 있었습니다.

### Key Changes
1. 예외 응답 전략 인터페이스와 추상 클래스를 도입하고, 예외 유형별 전략 및 `ExceptionStrategyFactory`를 추가했습니다.
2. `GlobalExceptionHandler`가 예외별 상태 코드·응답·로깅을 직접 처리하지 않고 전략 팩토리에 위임하도록 변경했습니다.
3. JWT 생성, 파싱, 서명, 검증, 인증 변환을 전용 빌더와 팩토리로 분리해 `JwtTokenProvider`의 책임을 축소했습니다.
4. JWT 파싱·검증 실패 시 민감한 토큰 정보가 로그에 노출되지 않도록 예외 메시지와 `User-Agent`를 sanitize 처리했습니다.
5. `Clock` 빈을 주입해 블랙리스트 스케줄러의 시간 의존성을 제어하고 테스트 재현성을 개선했습니다.
6. JWT 인증·검증·로그아웃, 로그인 실패, 블랙리스트, 서비스 및 예외 처리 테스트를 보강하고 AssertJ 기반 검증으로 정비했습니다.
7. Jacoco 커버리지 검증 기준을 80%로 상향하고 일부 공용·설정 클래스를 커버리지 대상에서 제외했습니다.

### 📊 Summary of Change Effects (If possible)
- 다수의 JWT·예외 처리 전략 및 테스트 클래스가 추가되었습니다.
- 단위 테스트와 통합 테스트가 대폭 보강되었습니다.
- Jacoco LINE 커버리지 최소 기준이 0%에서 80%로 변경되었습니다.
- 정확한 전체 변경 파일 수 및 테스트 수는 Not measured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->